### PR TITLE
Make type params in `KafkaClientInterface`'s source abstract

### DIFF
--- a/core/src/main/scala/aiven/io/guardian/kafka/KafkaClient.scala
+++ b/core/src/main/scala/aiven/io/guardian/kafka/KafkaClient.scala
@@ -17,6 +17,8 @@ import java.util.Base64
   * @param kafkaClusterConfig Additional cluster configuration that is needed
   */
 class KafkaClient()(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster) extends KafkaClientInterface {
+  override type Context = ConsumerMessage.CommittableOffset
+  override type Mat     = Consumer.Control
 
   private[kafka] val consumerSettings =
     ConsumerSettings(system, new ByteArrayDeserializer, new ByteArrayDeserializer)

--- a/core/src/main/scala/aiven/io/guardian/kafka/KafkaClientInterface.scala
+++ b/core/src/main/scala/aiven/io/guardian/kafka/KafkaClientInterface.scala
@@ -7,7 +7,16 @@ import akka.stream.scaladsl.SourceWithContext
 
 trait KafkaClientInterface {
 
+  /** The type of the context to pass around. In context of a Kafka consumer, this typically holds offset data to be
+    * automatically committed
+    */
+  type Context
+
+  /** A materializer that defines how to commit the cursor stored in `Context`
+    */
+  type Mat
+
   /** @return A `SourceWithContext` that returns a Kafka Stream which automatically handles committing of cursors
     */
-  def getSource: SourceWithContext[ReducedConsumerRecord, ConsumerMessage.CommittableOffset, Consumer.Control]
+  def getSource: SourceWithContext[ReducedConsumerRecord, Context, Mat]
 }


### PR DESCRIPTION
This PR makes the type parameters in `KafkaClientInterface` abstract so that its easier to mock and/or create alternate implementations (with a hardcoded  `ConsumerMessage.CommittableOffset`/`Consumer.Control` this makes it tied to Alpakka's implementation even though its meant to be a generic interface).