### PR TITLE
Refactor KafkaClientInterface plus add Circe encoder/decoder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val declineVersion             = "2.1.0"
 val pureConfigVersion          = "0.16.0"
 val scalaTestVersion           = "3.2.9"
 val scalaTestScalaCheckVersion = "3.2.9.0"
+val akkaStreamsJson            = "0.8.0"
 
 val flagsFor12 = Seq(
   "-Xlint:_",
@@ -69,6 +70,7 @@ lazy val core = project
       "com.typesafe.scala-logging" %% "scala-logging"     % scalaLoggingVersion,
       "com.github.pureconfig"      %% "pureconfig"        % pureConfigVersion,
       "ch.qos.logback"              % "logback-classic"   % logbackClassicVersion,
+      "org.mdedetrich"             %% "akka-stream-circe" % akkaStreamsJson,
       "org.scalatest"              %% "scalatest"         % scalaTestVersion           % Test,
       "org.scalatestplus"          %% "scalacheck-1-15"   % scalaTestScalaCheckVersion % Test
     )

--- a/core/src/main/scala/aiven/io/guardian/kafka/KafkaClientInterface.scala
+++ b/core/src/main/scala/aiven/io/guardian/kafka/KafkaClientInterface.scala
@@ -1,8 +1,6 @@
 package aiven.io.guardian.kafka
 
 import aiven.io.guardian.kafka.models.ReducedConsumerRecord
-import akka.kafka.ConsumerMessage
-import akka.kafka.scaladsl.Consumer
 import akka.stream.scaladsl.SourceWithContext
 
 trait KafkaClientInterface {
@@ -12,11 +10,11 @@ trait KafkaClientInterface {
     */
   type Context
 
-  /** A materializer that defines how to commit the cursor stored in `Context`
+  /** The type that represents how to control the given stream, i.e. if you want to shut it down or add metrics
     */
-  type Mat
+  type Control
 
   /** @return A `SourceWithContext` that returns a Kafka Stream which automatically handles committing of cursors
     */
-  def getSource: SourceWithContext[ReducedConsumerRecord, Context, Mat]
+  def getSource: SourceWithContext[ReducedConsumerRecord, Context, Control]
 }

--- a/core/src/main/scala/aiven/io/guardian/kafka/codecs/Circe.scala
+++ b/core/src/main/scala/aiven/io/guardian/kafka/codecs/Circe.scala
@@ -1,0 +1,38 @@
+package aiven.io.guardian.kafka.codecs
+
+import aiven.io.guardian.kafka.models.ReducedConsumerRecord
+import io.circe._
+import io.circe.syntax._
+import org.apache.kafka.common.record.TimestampType
+
+trait Circe {
+  implicit val kafkaTimestampTypeDecoder: Decoder[TimestampType] = (c: HCursor) =>
+    c.as[Int].flatMap { id =>
+      TimestampType
+        .values()
+        .find(_.id == id)
+        .toRight(DecodingFailure(s"No TimestampType with $id", c.history))
+    }
+
+  implicit val kafkaTimestampTypeEncoder = Encoder.instance[TimestampType](_.id.asJson)
+
+  implicit val reducedConsumerRecordDecoder: Decoder[ReducedConsumerRecord] = Decoder.forProduct6(
+    "topic",
+    "offset",
+    "key",
+    "value",
+    "timestamp",
+    "timestamp_type"
+  )(ReducedConsumerRecord.apply)
+
+  implicit val reducedConsumerRecordEncoder: Encoder[ReducedConsumerRecord] = Encoder.forProduct6(
+    "topic",
+    "offset",
+    "key",
+    "value",
+    "timestamp",
+    "timestamp_type"
+  )(x => ReducedConsumerRecord.unapply(x).get)
+}
+
+object Circe extends Circe

--- a/core/src/main/scala/aiven/io/guardian/kafka/models/ReducedConsumerRecord.scala
+++ b/core/src/main/scala/aiven/io/guardian/kafka/models/ReducedConsumerRecord.scala
@@ -5,15 +5,15 @@ import org.apache.kafka.common.record.TimestampType
 /** A `ConsumerRecord` that only contains the necessary data for guardian
   *
   * @param topic The kafka topic (same as `ConsumerRecord` `topic`)
-  * @param keyAsBase64 A Base64 encoded version of the original ConsumerRecord key as a byte array
-  * @param data The data (or value as in `ConsumerRecord`). The format is the original byte array since we don't care
-  *             about the message format
+  * @param key Base64 encoded version of the original ConsumerRecord key as a byte array
+  * @param value Base64 encoded version of the original ConsumerRecord value as a byte array
   * @param timestamp The timestamp value (same as `ConsumerRecord` `timestamp`)
   * @param timestampType The timestamp type (same as `ConsumerRecord` `timestampType`)
   */
 final case class ReducedConsumerRecord(topic: String,
-                                       keyAsBase64: String,
-                                       data: Array[Byte],
+                                       offset: Long,
+                                       key: String,
+                                       value: String,
                                        timestamp: Long,
                                        timestampType: TimestampType
 )


### PR DESCRIPTION
This PR does the following things

1. Makes the `ReducedConsumerRecord` Base64 encoded as well (since we are going to be storing it as JSON we need it as a string anyways)
2. Adds a Circe Encoder/Decoder so we can store it into S3/GCS as a json file
3. Renamed `Mat` to `Control` to make it more clear.