### PR TITLE
Set project.git=true for scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,7 +2,7 @@ version = 2.7.5
 preset = default
 align.preset = more
 maxColumn = 120
-project.git = false
+project.git = true
 align.tokens.add = [
   {code = ":=", owner = "Term.ApplyInfix"}
 ]


### PR DESCRIPTION
This PR sets `project.git = true` which means that scalafmt will only try to format files that are considered changed by `git`. It also means metals will respect `.gitignore`.