### PR TITLE
Use AnyPropSpec for property based tests

### DIFF
--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -1,12 +1,12 @@
 package io.aiven.guardian.kafka.backup
 
-import io.aiven.guardian.kafka.{Generators, ScalaTestConstants}
-import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import akka.actor.ActorSystem
+import io.aiven.guardian.kafka.models.ReducedConsumerRecord
+import io.aiven.guardian.kafka.{Generators, ScalaTestConstants}
 import org.scalacheck.Gen
 import org.scalatest.Inspectors
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.temporal.ChronoUnit
@@ -19,7 +19,7 @@ final case class Periods(periodsBefore: Long, periodsAfter: Long)
 final case class KafkaDataWithTimePeriod(data: List[ReducedConsumerRecord], periodSlice: FiniteDuration)
 
 class BackupClientInterfaceSpec
-    extends AnyWordSpec
+    extends AnyPropSpec
     with Matchers
     with ScalaCheckPropertyChecks
     with ScalaTestConstants {
@@ -40,107 +40,86 @@ class BackupClientInterfaceSpec
     duration <- Gen.choose[Long](head.timestamp, last.timestamp - 1).map(millis => FiniteDuration(millis, MILLISECONDS))
   } yield KafkaDataWithTimePeriod(records, duration)
 
-  "BackupClientInterface" can {
-    "splitAtBoundaryCondition" should {
-      "BackupStreamPosition.Boundary happy case" in {
-        forAll(periodGen.filter(x => x.periodsAfter > x.periodsBefore)) { (periods: Periods) =>
-          BackupClientInterface.splitAtBoundaryCondition(periods.periodsBefore,
-                                                         periods.periodsAfter
-          ) mustEqual BackupStreamPosition.Boundary
-        }
+  property("Ordered Kafka events should produce at least one BackupStreamPosition.Boundary") {
+    forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+                                                                    kafkaDataWithTimePeriod.periodSlice
+      )
+
+      val calculatedFuture = mock.materializeBackupStreamPositions()
+
+      val result = Await.result(calculatedFuture, AwaitTimeout).toList
+      val backupStreamPositions = result.map { case (_, backupStreamPosition) =>
+        backupStreamPosition
       }
 
-      "BackupStreamPosition.Middle happy case" in {
-        forAll(periodGen.filter(x => !(x.periodsAfter > x.periodsBefore))) { (periods: Periods) =>
-          BackupClientInterface.splitAtBoundaryCondition(periods.periodsBefore,
-                                                         periods.periodsAfter
-          ) mustEqual BackupStreamPosition.Middle
+      Inspectors.forAtLeast(1, backupStreamPositions)(_ mustEqual BackupStreamPosition.Boundary)
+    }
+  }
+
+  property(
+    "Every ReducedConsumerRecord after a BackupStreamPosition.Boundary should be in the next consecutive time period"
+  ) {
+    forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+                                                                    kafkaDataWithTimePeriod.periodSlice
+      )
+
+      val calculatedFuture = mock.materializeBackupStreamPositions()
+
+      val result = Await.result(calculatedFuture, AwaitTimeout).toList
+
+      val allBoundariesWithoutMiddles = result
+        .sliding(2)
+        .collect { case Seq((_, _: BackupStreamPosition.Boundary.type), (afterRecord, _)) =>
+          afterRecord
+        }
+        .toList
+
+      if (allBoundariesWithoutMiddles.length > 1) {
+        @nowarn("msg=not.*?exhaustive")
+        val withBeforeAndAfter =
+          allBoundariesWithoutMiddles.sliding(2).map { case Seq(before, after) => (before, after) }.toList
+
+        val initialTime = kafkaDataWithTimePeriod.data.head.timestamp
+
+        Inspectors.forEvery(withBeforeAndAfter) { case (before, after) =>
+          val periodAsMillis = kafkaDataWithTimePeriod.periodSlice.toMillis
+          ((before.timestamp - initialTime) / periodAsMillis) mustNot equal(
+            (after.timestamp - initialTime) / periodAsMillis
+          )
         }
       }
     }
+  }
 
-    "calculateBackupStreamPositions" should {
+  property(
+    "The time difference between two consecutive BackupStreamPosition.Middle's has to be less then the specified time period"
+  ) {
+    forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+                                                                    kafkaDataWithTimePeriod.periodSlice
+      )
 
-      "must always have at least one BackupStreamPosition.Boundary" in {
-        forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-          val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
-                                                                        kafkaDataWithTimePeriod.periodSlice
-          )
+      val calculatedFuture = mock.materializeBackupStreamPositions()
 
-          val calculatedFuture = mock.materializeBackupStreamPositions()
+      val result = Await.result(calculatedFuture, AwaitTimeout).toList
 
-          val result = Await.result(calculatedFuture, AwaitTimeout).toList
-          val backupStreamPositions = result.map { case (_, backupStreamPosition) =>
-            backupStreamPosition
-          }
-
-          // We must always have at least one Boundary, a single Middle makes no sense
-          Inspectors.forAtLeast(1, backupStreamPositions)(_ mustEqual BackupStreamPosition.Boundary)
+      val allCoupledMiddles = result
+        .sliding(2)
+        .collect {
+          case Seq((beforeRecord, _: BackupStreamPosition.Middle.type),
+                   (afterRecord, _: BackupStreamPosition.Middle.type)
+              ) =>
+            (beforeRecord, afterRecord)
         }
+        .toList
+
+      Inspectors.forEvery(allCoupledMiddles) { case (before, after) =>
+        ChronoUnit.MICROS.between(before.toOffsetDateTime,
+                                  after.toOffsetDateTime
+        ) must be < kafkaDataWithTimePeriod.periodSlice.toMicros
       }
-
-      "Every ReducedConsumerRecord after a BackupStreamPosition.Boundary must be in the next consecutive time period" in {
-        forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-          val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
-                                                                        kafkaDataWithTimePeriod.periodSlice
-          )
-
-          val calculatedFuture = mock.materializeBackupStreamPositions()
-
-          val result = Await.result(calculatedFuture, AwaitTimeout).toList
-
-          val allBoundariesWithoutMiddles = result
-            .sliding(2)
-            .collect { case Seq((_, _: BackupStreamPosition.Boundary.type), (afterRecord, _)) =>
-              afterRecord
-            }
-            .toList
-
-          if (allBoundariesWithoutMiddles.length > 1) {
-            @nowarn("msg=not.*?exhaustive")
-            val withBeforeAndAfter =
-              allBoundariesWithoutMiddles.sliding(2).map { case Seq(before, after) => (before, after) }.toList
-
-            val initialTime = kafkaDataWithTimePeriod.data.head.timestamp
-
-            Inspectors.forEvery(withBeforeAndAfter) { case (before, after) =>
-              val periodAsMillis = kafkaDataWithTimePeriod.periodSlice.toMillis
-              ((before.timestamp - initialTime) / periodAsMillis) mustNot equal(
-                (after.timestamp - initialTime) / periodAsMillis
-              )
-            }
-          }
-        }
-      }
-
-      "The time difference between two consecutive BackupStreamPosition.Middle has to be less then the time period" in {
-        forAll(kafkaDataWithTimePeriodsGen) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-          val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
-                                                                        kafkaDataWithTimePeriod.periodSlice
-          )
-
-          val calculatedFuture = mock.materializeBackupStreamPositions()
-
-          val result = Await.result(calculatedFuture, AwaitTimeout).toList
-
-          val allCoupledMiddles = result
-            .sliding(2)
-            .collect {
-              case Seq((beforeRecord, _: BackupStreamPosition.Middle.type),
-                       (afterRecord, _: BackupStreamPosition.Middle.type)
-                  ) =>
-                (beforeRecord, afterRecord)
-            }
-            .toList
-
-          Inspectors.forEvery(allCoupledMiddles) { case (before, after) =>
-            ChronoUnit.MICROS.between(before.toOffsetDateTime,
-                                      after.toOffsetDateTime
-            ) must be < kafkaDataWithTimePeriod.periodSlice.toMicros
-          }
-        }
-      }
-
     }
   }
 }

--- a/core/src/test/scala/io/aiven/guardian/kafka/ConfigSpec.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/ConfigSpec.scala
@@ -3,16 +3,16 @@ package io.aiven.guardian.kafka
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pureconfig.ConfigSource
 
-class ConfigSpec extends AnyWordSpec with Matchers with ScalaCheckPropertyChecks {
+class ConfigSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
   implicit val kafkaClusterArb = Arbitrary(
     Gen.containerOf[Set, String](Gen.alphaStr).map(topics => KafkaCluster(topics))
   )
 
-  "Load KafkaClusterConfig with valid topics" in {
+  property("Valid KafkaClusterConfig configs should parse correctly") {
     forAll { (kafkaClusterConfig: KafkaCluster) =>
       val conf =
         s"""


### PR DESCRIPTION
Using the `AnyWordSpec` didn't make sense for the style/type of tests (i.e. property based tests) that were being written so this PR changes the tests to use `AnyPropSpec` so its more legible.

The tests now output this

```
[info] All tests passed.
[info] PureConfigS3HeadersSpec:
[info] - Valid CannedAcl configs should parse correctly
[info] - Valid MetaHeaders configs should parse correctly
[info] - Valid StorageClass configs should parse correctly
[info] - Valid ServerSideEncryption configs should parse correctly
[info] - Valid S3Headers configs should parse correctly
[info] Run completed in 594 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] done compiling
[info] BackupClientInterfaceSpec:
[info] - Ordered Kafka events should produce at least one BackupStreamPosition.Boundary
[info] - Every ReducedConsumerRecord after a BackupStreamPosition.Boundary should be in the next consecutive time period
[info] - The time difference between two consecutive BackupStreamPosition.Middle's has to be less then the specified time period
[info] Run completed in 485 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 2 s, completed Aug 11, 2021, 1:58:15 PM
```