### PR TITLE
Bump to Alpakka 3.0.3 and update associated tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / organizationHomepage := Some(url("https://aiven.io/"))
 
 val akkaVersion                = "2.6.15"
 val alpakkaKafkaVersion        = "2.1.1"
-val alpakkaVersion             = "3.0.2"
+val alpakkaVersion             = "3.0.3"
 val quillJdbcMonixVersion      = "3.7.2"
 val postgresqlJdbcVersion      = "42.2.23"
 val scalaLoggingVersion        = "3.9.4"


### PR DESCRIPTION
Bumps to latest alpakka which also fixes the various `equals` issue for the config so the associated test workarounds have been removed.