### PR TITLE
Add guard on push and pull_request actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: [main]
   push:
-    branches: ['**']
+    branches: [main]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -213,6 +213,8 @@ lazy val cliRestore = project
 // This is currently causing problems, see https://github.com/djspiewak/sbt-github-actions/issues/74
 ThisBuild / githubWorkflowUseSbtThinClient := false
 
+ThisBuild / githubWorkflowTargetBranches := Seq("main") // Once we have branches per version, add the pattern here
+
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
 import ReleaseTransformations._


### PR DESCRIPTION
Trigger ci pipeline only on pull_requests that want to merge to main or push events on the main branch.