### PR TITLE
Add diffx to tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ val pureConfigVersion          = "0.16.0"
 val scalaTestVersion           = "3.2.9"
 val scalaTestScalaCheckVersion = "3.2.9.0"
 val akkaStreamsJson            = "0.8.0"
+val diffxVersion               = "0.5.6"
 
 val flagsFor12 = Seq(
   "-Xlint:_",
@@ -74,7 +75,8 @@ lazy val core = project
       "ch.qos.logback"              % "logback-classic"   % logbackClassicVersion,
       "org.mdedetrich"             %% "akka-stream-circe" % akkaStreamsJson,
       "org.scalatest"              %% "scalatest"         % scalaTestVersion           % Test,
-      "org.scalatestplus"          %% "scalacheck-1-15"   % scalaTestScalaCheckVersion % Test
+      "org.scalatestplus"          %% "scalacheck-1-15"   % scalaTestScalaCheckVersion % Test,
+      "com.softwaremill.diffx"     %% "diffx-scalatest"   % diffxVersion               % Test
     )
   )
 
@@ -107,11 +109,7 @@ lazy val coreBackup = project
   .in(file("core-backup"))
   .settings(
     librarySettings,
-    name := s"$baseName-core-backup",
-    libraryDependencies ++= Seq(
-      "org.scalatest"     %% "scalatest"       % scalaTestVersion           % Test,
-      "org.scalatestplus" %% "scalacheck-1-15" % scalaTestScalaCheckVersion % Test
-    )
+    name := s"$baseName-core-backup"
   )
   .dependsOn(coreAws % "compile->compile;test->test")
 

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -1,6 +1,8 @@
 package io.aiven.guardian.kafka.backup
 
 import akka.actor.ActorSystem
+import com.softwaremill.diffx.generic.auto._
+import com.softwaremill.diffx.scalatest.DiffMatcher._
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import io.aiven.guardian.kafka.{Generators, ScalaTestConstants}
 import org.scalacheck.Gen
@@ -53,7 +55,9 @@ class BackupClientInterfaceSpec
         backupStreamPosition
       }
 
-      Inspectors.forAtLeast(1, backupStreamPositions)(_ mustEqual BackupStreamPosition.Boundary)
+      Inspectors.forAtLeast(1, backupStreamPositions)(
+        _ must matchTo(BackupStreamPosition.Boundary: BackupStreamPosition)
+      )
     }
   }
 

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/PureConfigS3HeadersSpec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/PureConfigS3HeadersSpec.scala
@@ -1,12 +1,15 @@
 package io.aiven.guardian.kafka.s3
 
-import io.aiven.guardian.kafka.s3.Config._
+import akka.stream.alpakka.s3.headers._
 import akka.stream.alpakka.s3.{MetaHeaders, S3Headers}
-import akka.stream.alpakka.s3.headers.{AES256, CannedAcl, CustomerKeys, KMS, ServerSideEncryption, StorageClass}
+import com.softwaremill.diffx.generic.auto._
+import com.softwaremill.diffx.scalatest.DiffMatcher._
+import io.aiven.guardian.kafka.s3.Config._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pureconfig.ConfigReader.Result
 import pureconfig.ConfigSource
 
 class PureConfigS3HeadersSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
@@ -123,32 +126,32 @@ class PureConfigS3HeadersSpec extends AnyPropSpec with Matchers with ScalaCheckP
 
   property("Valid CannedAcl configs should parse correctly") {
     forAll { (cannedAcl: CannedAcl) =>
-      ConfigSource.string(s"test=${configCannedAcl(cannedAcl)}").at("test").load[CannedAcl] must be(
-        Right(cannedAcl)
+      ConfigSource.string(s"test=${configCannedAcl(cannedAcl)}").at("test").load[CannedAcl] must matchTo(
+        Right(cannedAcl): Result[CannedAcl]
       )
     }
   }
 
   property("Valid MetaHeaders configs should parse correctly") {
     forAll { (metaHeaders: MetaHeaders) =>
-      ConfigSource.string(configMetaHeaders(metaHeaders)).load[MetaHeaders] must be(
-        Right(metaHeaders)
+      ConfigSource.string(configMetaHeaders(metaHeaders)).load[MetaHeaders] must matchTo(
+        Right(metaHeaders): Result[MetaHeaders]
       )
     }
   }
 
   property("Valid StorageClass configs should parse correctly") {
     forAll { (storageClass: StorageClass) =>
-      ConfigSource.string(s"test=${configStorageClass(storageClass)}").at("test").load[StorageClass] must be(
-        Right(storageClass)
+      ConfigSource.string(s"test=${configStorageClass(storageClass)}").at("test").load[StorageClass] must matchTo(
+        Right(storageClass): Result[StorageClass]
       )
     }
   }
 
   property("Valid ServerSideEncryption configs should parse correctly") {
     forAll { (serverSideEncryption: ServerSideEncryption) =>
-      ConfigSource.string(configServerSideEncryption(serverSideEncryption)).load[ServerSideEncryption] must be(
-        Right(serverSideEncryption)
+      ConfigSource.string(configServerSideEncryption(serverSideEncryption)).load[ServerSideEncryption] must matchTo(
+        Right(serverSideEncryption): Result[ServerSideEncryption]
       )
     }
   }
@@ -165,8 +168,8 @@ class PureConfigS3HeadersSpec extends AnyPropSpec with Matchers with ScalaCheckP
         s"server-side-encryption={\n${configServerSideEncryption(serverSideEncryption)}\n}"
       )}
           |""".stripMargin
-      ConfigSource.string(string).load[S3Headers] must be(
-        Right(s3Headers)
+      ConfigSource.string(string).load[S3Headers] must matchTo(
+        Right(s3Headers): Result[S3Headers]
       )
     }
   }


### PR DESCRIPTION
# About this change - What it does

This PR adds [diffx](https://github.com/softwaremill/diffx) to our test suite

# Why this way

When tests fail it can become very difficult to pinpoint the precise area where the tests fail. Diffx (along with its integration with scalatest) lets you print out very nice diffs whenever a test fails.

You can also manually use diffx to create a comparison between any 2 data structures, I am currently doing this to solve https://github.com/aiven/guardian-for-apache-kafka/pull/25

See https://diffx-scala.readthedocs.io/en/latest/test-frameworks/specs2.html for how the integration with scalatest works.