### PR TITLE
Add akka test kit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ ThisBuild / organizationName     := "Aiven"
 ThisBuild / organizationHomepage := Some(url("https://aiven.io/"))
 
 val akkaVersion                = "2.6.15"
+val akkaHttpVersion            = "10.2.6"
 val alpakkaKafkaVersion        = "2.1.1"
 val alpakkaVersion             = "3.0.3"
 val quillJdbcMonixVersion      = "3.7.2"
@@ -69,15 +70,17 @@ lazy val core = project
     librarySettings,
     name := s"$baseName-core",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"          %% "akka-stream"       % akkaVersion,
-      "com.typesafe.akka"          %% "akka-stream-kafka" % alpakkaKafkaVersion,
-      "com.typesafe.scala-logging" %% "scala-logging"     % scalaLoggingVersion,
-      "com.github.pureconfig"      %% "pureconfig"        % pureConfigVersion,
-      "ch.qos.logback"              % "logback-classic"   % logbackClassicVersion,
-      "org.mdedetrich"             %% "akka-stream-circe" % akkaStreamsJson,
-      "org.scalatest"              %% "scalatest"         % scalaTestVersion           % Test,
-      "org.scalatestplus"          %% "scalacheck-1-15"   % scalaTestScalaCheckVersion % Test,
-      "com.softwaremill.diffx"     %% "diffx-scalatest"   % diffxVersion               % Test
+      "com.typesafe.akka"          %% "akka-stream"         % akkaVersion,
+      "com.typesafe.akka"          %% "akka-stream-kafka"   % alpakkaKafkaVersion,
+      "com.typesafe.scala-logging" %% "scala-logging"       % scalaLoggingVersion,
+      "com.github.pureconfig"      %% "pureconfig"          % pureConfigVersion,
+      "ch.qos.logback"              % "logback-classic"     % logbackClassicVersion,
+      "org.mdedetrich"             %% "akka-stream-circe"   % akkaStreamsJson,
+      "org.scalatest"              %% "scalatest"           % scalaTestVersion           % Test,
+      "org.scalatestplus"          %% "scalacheck-1-15"     % scalaTestScalaCheckVersion % Test,
+      "com.softwaremill.diffx"     %% "diffx-scalatest"     % diffxVersion               % Test,
+      "com.typesafe.akka"          %% "akka-stream-testkit" % akkaVersion                % Test,
+      "com.typesafe.akka"          %% "akka-http-testkit"   % akkaHttpVersion            % Test
     )
   )
 
@@ -90,7 +93,8 @@ lazy val coreS3 = project
       "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion,
       "org.scalatest"      %% "scalatest"              % scalaTestVersion           % Test,
       "org.scalatestplus"  %% "scalacheck-1-15"        % scalaTestScalaCheckVersion % Test,
-      "com.adobe.testing"   % "s3mock"                 % s3MockVersion              % Test
+      "com.adobe.testing"   % "s3mock"                 % s3MockVersion              % Test,
+      "com.typesafe.akka"  %% "akka-http-xml"          % akkaHttpVersion            % Test
     )
   )
   .dependsOn(core % "compile->compile;test->test")

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher._
+import io.aiven.guardian.akka.{AnyPropTestKit, AkkaStreamTestKit}
 import io.aiven.guardian.kafka.codecs.Circe._
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import io.aiven.guardian.kafka.{Generators, ScalaTestConstants}
@@ -11,7 +12,6 @@ import org.mdedetrich.akka.stream.support.CirceStreamSupport
 import org.scalacheck.Gen
 import org.scalatest.Inspectors
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.temporal.ChronoUnit
@@ -25,12 +25,11 @@ final case class Periods(periodsBefore: Long, periodsAfter: Long)
 final case class KafkaDataWithTimePeriod(data: List[ReducedConsumerRecord], periodSlice: FiniteDuration)
 
 class BackupClientInterfaceSpec
-    extends AnyPropSpec
+    extends AnyPropTestKit(ActorSystem("BackupClientInterfaceSpec"))
+    with AkkaStreamTestKit
     with Matchers
     with ScalaCheckPropertyChecks
     with ScalaTestConstants {
-
-  implicit val system: ActorSystem = ActorSystem()
 
   val periodGen = for {
     before <- Gen.long

--- a/core/src/test/scala/io/aiven/guardian/akka/AkkaHttpTestKit.scala
+++ b/core/src/test/scala/io/aiven/guardian/akka/AkkaHttpTestKit.scala
@@ -1,0 +1,16 @@
+package io.aiven.guardian.akka
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import org.scalatest.Suite
+
+trait AkkaHttpTestKit extends AkkaStreamTestKit { this: Suite =>
+  implicit val system: ActorSystem
+
+  override protected def afterAll(): Unit =
+    Http(system)
+      .shutdownAllConnectionPools()
+      .foreach { _ =>
+        super.afterAll()
+      }(system.dispatcher)
+}

--- a/core/src/test/scala/io/aiven/guardian/akka/AkkaStreamTestKit.scala
+++ b/core/src/test/scala/io/aiven/guardian/akka/AkkaStreamTestKit.scala
@@ -1,0 +1,12 @@
+package io.aiven.guardian.akka
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestKit, TestKitBase}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait AkkaStreamTestKit extends TestKitBase with BeforeAndAfterAll { this: Suite =>
+  implicit val system: ActorSystem
+
+  override protected def afterAll(): Unit =
+    TestKit.shutdownActorSystem(system)
+}

--- a/core/src/test/scala/io/aiven/guardian/akka/AnyPropTestKit.scala
+++ b/core/src/test/scala/io/aiven/guardian/akka/AnyPropTestKit.scala
@@ -1,0 +1,9 @@
+package io.aiven.guardian.akka
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKitBase
+import org.scalatest.propspec.AnyPropSpec
+
+class AnyPropTestKit(_system: ActorSystem) extends AnyPropSpec with TestKitBase {
+  implicit val system: ActorSystem = _system
+}


### PR DESCRIPTION
# About this change - What it does

This test adds akka-testkit to initialize the actorsystem within our tests (rather than doing it manually like before). It also adds some convenience traits for properly shutting down the actorsystem and/or akka-http

References: #35 

# Why this way

This test adds akka testkit into our testing framework so we can properly initialize and shutdown the actor system. 3 new traits/classes were added, detailed below

* `AnyPropTestKit` which any test that typically uses `AnyPropsSpec` would extend while also providing an `ActorSystem` (ideally named). This class exists because both `AnyPropSpec` and `TestKit` are classes and since you cannot extend multiple classes in Scala I had to create `AnyPropTestKit`
* `AkkaStreamTestKit` which provides the standard actor shutdown semantics. Tests that **don't** use akka-http should extend this trait to cleanup the actor system properly
* `AkkaHttpTestKit` which provides a Http shutdown sequence that also correctly shuts down the `ActorSystem` afterwards. Tests that involve akka-http (i.e. alpakka-s3 that uses akka-http internally) should extend this trait
