### PR TITLE
Cleanup and refactor tests

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -2,28 +2,23 @@ package io.aiven.guardian.kafka.backup.s3
 
 import akka.actor.ActorSystem
 import akka.stream.Attributes
+import akka.stream.alpakka.s3.S3Attributes
 import akka.stream.alpakka.s3.scaladsl.S3
-import akka.stream.alpakka.s3.{AccessStyle, S3Attributes, S3Settings}
 import akka.stream.scaladsl.{Keep, Sink}
-import com.dimafeng.testcontainers.ForAllTestContainer
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher.matchTo
 import io.aiven.guardian.akka.{AkkaHttpTestKit, AnyPropTestKit}
-import io.aiven.guardian.kafka.backup.{KafkaDataWithTimePeriod, Periods}
+import io.aiven.guardian.kafka.Generators._
+import io.aiven.guardian.kafka.ScalaTestConstants
 import io.aiven.guardian.kafka.codecs.Circe._
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import io.aiven.guardian.kafka.s3.Generators._
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import io.aiven.guardian.kafka.s3.errors.S3Errors
-import io.aiven.guardian.kafka.s3.{Config, MinioContainer}
-import io.aiven.guardian.kafka.{Generators, ScalaTestConstants}
+import io.aiven.guardian.kafka.s3.{Config, MinioS3Test}
 import org.mdedetrich.akka.stream.support.CirceStreamSupport
-import org.scalacheck.Gen
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.regions.providers.AwsRegionProvider
 
 import java.time.OffsetDateTime
 import scala.concurrent.duration._
@@ -36,47 +31,14 @@ class BackupClientSpec
     with Matchers
     with ScalaCheckPropertyChecks
     with ScalaTestConstants
-    with ForAllTestContainer
+    with MinioS3Test
     with Config {
 
-  val DummyAccessKey   = "DUMMY_ACCESS_KEY"
-  val DummySecretKey   = "DUMMY_SECRET_KEY"
   val ThrottleElements = 100
   val ThrottleAmount   = 1 millis
 
-  lazy val s3Settings = S3Settings()
-    .withEndpointUrl(s"http://${container.getHostAddress}")
-    .withCredentialsProvider(
-      StaticCredentialsProvider.create(AwsBasicCredentials.create(DummyAccessKey, DummySecretKey))
-    )
-    .withS3RegionProvider(new AwsRegionProvider {
-      lazy val getRegion: Region = Region.US_EAST_1
-    })
-    .withAccessStyle(AccessStyle.PathAccessStyle)
-
-  override val container: MinioContainer = new MinioContainer(DummyAccessKey, DummySecretKey)
-
-  val periodGen = for {
-    before <- Gen.long
-    after  <- Gen.long
-  } yield Periods(before, after)
-
-  val s3ConfigGen = (for {
-    dataBucket       <- bucketNameGen
-    compactionBucket <- bucketNameGen
-  } yield S3Config(dataBucket, compactionBucket)).filter(config => config.dataBucket != config.compactionBucket)
-
-  def kafkaDataWithTimePeriodsGen: Gen[KafkaDataWithTimePeriod] = for {
-    topic   <- Gen.alphaStr
-    records <- Generators.kafkaReducedConsumerRecordsGen(topic, 2, 100, 10)
-    head = records.head
-    last = records.last
-
-    duration <- Gen.choose[Long](head.timestamp, last.timestamp - 1).map(millis => FiniteDuration(millis, MILLISECONDS))
-  } yield KafkaDataWithTimePeriod(records, duration)
-
   property("backup method completes flow correctly for all valid Kafka events") {
-    forAll(kafkaDataWithTimePeriodsGen, s3ConfigGen) {
+    forAll(kafkaDataWithTimePeriodsGen(), s3ConfigGen) {
       (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
         val backupClient = new MockedS3BackupClientInterface(kafkaDataWithTimePeriod.data,
                                                              kafkaDataWithTimePeriod.periodSlice,

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Generators.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Generators.scala
@@ -1,5 +1,6 @@
 package io.aiven.guardian.kafka.s3
 
+import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import org.scalacheck.Gen
 
 import scala.annotation.nowarn
@@ -45,4 +46,10 @@ object Generators {
                     }
     } yield bucketName
   }
+
+  val s3ConfigGen = (for {
+    dataBucket       <- bucketNameGen
+    compactionBucket <- bucketNameGen
+  } yield S3Config(dataBucket, compactionBucket)).filter(config => config.dataBucket != config.compactionBucket)
+
 }

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/MinioS3Test.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/MinioS3Test.scala
@@ -1,0 +1,26 @@
+package io.aiven.guardian.kafka.s3
+
+import akka.stream.alpakka.s3.{AccessStyle, S3Settings}
+import akka.testkit.TestKitBase
+import com.dimafeng.testcontainers.ForAllTestContainer
+import org.scalatest.Suite
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers.AwsRegionProvider
+
+trait MinioS3Test extends ForAllTestContainer with TestKitBase { this: Suite =>
+  val S3DummyAccessKey = "DUMMY_ACCESS_KEY"
+  val S3DummySecretKey = "DUMMY_SECRET_KEY"
+
+  lazy val s3Settings = S3Settings()
+    .withEndpointUrl(s"http://${container.getHostAddress}")
+    .withCredentialsProvider(
+      StaticCredentialsProvider.create(AwsBasicCredentials.create(S3DummyAccessKey, S3DummySecretKey))
+    )
+    .withS3RegionProvider(new AwsRegionProvider {
+      lazy val getRegion: Region = Region.US_EAST_1
+    })
+    .withAccessStyle(AccessStyle.PathAccessStyle)
+
+  override val container: MinioContainer = new MinioContainer(S3DummyAccessKey, S3DummySecretKey)
+}

--- a/core/src/test/scala/io/aiven/guardian/kafka/MockedKafkaClientInterface.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/MockedKafkaClientInterface.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
   *   The data which the mock will output
   * @param sourceTransform
   *   A function that allows you to transform the source in some way. Convenient for cases such as throttling. By
-  *   default this is `None` so no changes are done.
+  *   default this is `None` so it just preserves the original source.
   */
 class MockedKafkaClientInterface(
     kafkaData: List[ReducedConsumerRecord],


### PR DESCRIPTION
# About this change - What it does

This PR cleans up tests by removing boilerplate along with abstracting common functionality into traits.

# Why this way

There was a lot of code duplication with scalacheck generators that was moved into the appropriate `Generators` object and functionality such as setting up an S3 Minio container was moved into its own trait. I also optimized imports using Intellij so its more clean/remove duplication.

There was also some code which wasn't doing anything (i.e. `periodGen`)