### PR TITLE
Add ConfigReader for GCS/S3 configs

### DIFF
--- a/core-gcs/src/main/resources/reference.conf
+++ b/core-gcs/src/main/resources/reference.conf
@@ -1,0 +1,4 @@
+gcs-config = {
+    data-bucket = ${?GCS_CONFIG_DATA_BUCKET}
+    compaction-bucket = ${?GCS_CONFIG_COMPACTION_BUCKET}
+}

--- a/core-gcs/src/main/scala/io/aiven/guardian/kafka/gcs/Config.scala
+++ b/core-gcs/src/main/scala/io/aiven/guardian/kafka/gcs/Config.scala
@@ -1,0 +1,15 @@
+package io.aiven.guardian.kafka.gcs
+
+import io.aiven.guardian.kafka.gcs.configs.GCS
+import pureconfig._
+import pureconfig.generic.auto._
+
+import scala.annotation.nowarn
+
+trait Config {
+  @nowarn("cat=lint-byname-implicit")
+  implicit lazy val gcsConfig: GCS =
+    ConfigSource.default.at("gcs-config").loadOrThrow[GCS]
+}
+
+object Config extends Config

--- a/core-s3/src/main/resources/reference.conf
+++ b/core-s3/src/main/resources/reference.conf
@@ -46,3 +46,10 @@ s3-headers = {
     storage-class = ${?S3_HEADERS_STORAGE_CLASS}
     server-side-encryption = ${?S3_HEADERS_SERVER_SIDE_ENCRYPTION}
 }
+
+s3-config = {
+    data-bucket = ${?S3_CONFIG_DATA_BUCKET}
+    data-bucket-prefix = ${?S3_CONFIG_DATA_BUCKET_PREFIX}
+    compaction-bucket = ${?S3_CONFIG_COMPACTION_BUCKET}
+    compaction-bucket-prefix = ${?S3_CONFIG_COMPACTION_BUCKET_PREFIX}
+}

--- a/core-s3/src/main/scala/io/aiven/guardian/kafka/s3/Config.scala
+++ b/core-s3/src/main/scala/io/aiven/guardian/kafka/s3/Config.scala
@@ -1,11 +1,14 @@
 package io.aiven.guardian.kafka
 package s3
 
-import io.aiven.guardian.kafka.PureConfigUtils._
 import akka.stream.alpakka.s3.headers.{CannedAcl, ServerSideEncryption, StorageClass}
 import akka.stream.alpakka.s3.{MetaHeaders, S3Headers}
+import io.aiven.guardian.kafka.PureConfigUtils._
+import io.aiven.guardian.kafka.s3.configs.S3
 import pureconfig.ConfigReader._
 import pureconfig.{ConfigCursor, ConfigReader, ConfigSource}
+
+import scala.annotation.nowarn
 
 trait Config {
 
@@ -78,6 +81,12 @@ trait Config {
     }
 
   implicit lazy val s3Headers: S3Headers = ConfigSource.default.at("s3-headers").loadOrThrow[S3Headers]
+
+  @nowarn("cat=lint-byname-implicit")
+  implicit lazy val s3Config: S3 = {
+    import pureconfig.generic.auto._
+    ConfigSource.default.at("s3-config").loadOrThrow[S3]
+  }
 }
 
 object Config extends Config


### PR DESCRIPTION
# About this change - What it does

This PR adds an implicit lazy val configuration for the S3/GCS configs.

# Why this way

 In this case these configs were just missing, we already do this for other configs so its nothing special.
