### PR TITLE
Remove unneeded unused imports compiler flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,6 @@ val flagsFor13 = Seq(
   "-opt-inline-from:<sources>",
   "-opt:l:method",
   "-Xfatal-warnings",
-  "-Ywarn-unused",
   "-Xlint:adapted-args",
   "-Wconf:cat=unused:info"
 )


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This PR removes a now unneeded (since https://github.com/aiven/guardian-for-apache-kafka/pull/52) flag

# Why this way

This compiler flag is being removed primarily due to how impractical it is when working on Scala codebase locally. Its quite typical that when you are writing code (especially tests) that you quickly move around/create imports and hence you may have some lying around (i.e. unused) as you are trying to do things quickly. Having the `"-Ywarn-unused"` creates friction in this process since its on compile step, you have continuously re-optimize your imports whenever you test/compile, ideally you only want to do this when you actually submit your PR and its in final stages.

Even with these downsides, the flag made obvious sense as a rudimentary linting tool but since we now have scalafix which removes unused imports (and checks this on PR), this flag is no longer needed.