### PR TITLE
Set `chunkingParallelism = 1` for S3 multipart upload

### DIFF
--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -31,7 +31,8 @@ class BackupClient[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings
       .multipartUploadWithHeaders(
         s3Config.dataBucket,
         key,
-        s3Headers = s3Headers
+        s3Headers = s3Headers,
+        chunkingParallelism = 1 // Parallelism is pointless for this usecase since we are directly streaming from Kafka
       )
       .mapMaterializedValue(future => future.map(result => Some(result))(ExecutionContext.parasitic))
     maybeS3Settings.fold(base)(s3Settings => base.withAttributes(S3Attributes.settings(s3Settings)))


### PR DESCRIPTION
# About this change - What it does

This PR sets `chunkingParallelism = 1` for S3 multipart upload

# Why this way

For our specific usecase of guardian, chunking parallelism for multipart upload is useless because we immediately push a chunk into S3 as soon as we process it. Chunking parallelism is mainly useful for the usecase where you already have a massive file which you can immediately split into chunks and upload in parallel.