### PR TITLE
Use resolves instead of references so linked issues get closed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 <!-- Provide a small sentence that summarizes the change. -->
 
 <!-- Provide the issue number below if it exists. -->
-References: #xxxxx
+Resolves: #xxxxx
 
 # Why this way
 


### PR DESCRIPTION
# About this change - What it does
This PR changes the pull request template so that it uses `Resolves` instead of `References`.

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

This change means that by default the PR will get linked to the issue so if one merges the PR into main then the linked issue is automatically closed. References isn't in the list of sanctioned keywords which causes a PR to get properly linked to an issue.

See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword as a reference