### PR TITLE
Make library modules have akka dependencies as provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,12 +74,15 @@ lazy val core = project
     librarySettings,
     name := s"$baseName-core",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"          %% "akka-stream"                    % akkaVersion,
+      "com.typesafe.akka"          %% "akka-actor"                     % akkaVersion                % Provided,
+      "com.typesafe.akka"          %% "akka-stream"                    % akkaVersion                % Provided,
       "com.typesafe.akka"          %% "akka-stream-kafka"              % alpakkaKafkaVersion,
       "com.typesafe.scala-logging" %% "scala-logging"                  % scalaLoggingVersion,
       "com.github.pureconfig"      %% "pureconfig"                     % pureConfigVersion,
       "ch.qos.logback"              % "logback-classic"                % logbackClassicVersion,
       "org.mdedetrich"             %% "akka-stream-circe"              % akkaStreamsJson,
+      "com.typesafe.akka"          %% "akka-actor"                     % akkaVersion                % Test,
+      "com.typesafe.akka"          %% "akka-stream"                    % akkaVersion                % Test,
       "org.scalatest"              %% "scalatest"                      % scalaTestVersion           % Test,
       "org.scalatestplus"          %% "scalacheck-1-15"                % scalaTestScalaCheckVersion % Test,
       "com.softwaremill.diffx"     %% "diffx-scalatest"                % diffxVersion               % Test,
@@ -149,7 +152,9 @@ lazy val cliBackup = project
     cliSettings,
     name := s"$baseName-cli-backup",
     libraryDependencies ++= Seq(
-      "com.monovore" %% "decline" % declineVersion
+      "com.typesafe.akka" %% "akka-actor"  % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.monovore"      %% "decline"     % declineVersion
     )
   )
   .dependsOn(backupS3, backupGCS)
@@ -188,7 +193,9 @@ lazy val cliCompaction = project
     cliSettings,
     name := s"$baseName-cli-compaction",
     libraryDependencies ++= Seq(
-      "com.monovore" %% "decline" % declineVersion
+      "com.typesafe.akka" %% "akka-actor"  % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.monovore"      %% "decline"     % declineVersion
     )
   )
   .dependsOn(compactionS3, compactionGCS)
@@ -216,7 +223,9 @@ lazy val cliRestore = project
     cliSettings,
     name := s"$baseName-cli-restore",
     libraryDependencies ++= Seq(
-      "com.monovore" %% "decline" % declineVersion
+      "com.typesafe.akka" %% "akka-actor"  % akkaVersion,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.monovore"      %% "decline"     % declineVersion
     )
   )
   .dependsOn(restoreS3, restoreGCS)


### PR DESCRIPTION
# About this change - What it does

Due to how akka libraries work with bincompat this PR changes akka dependencies for library modules (such as core) to use `Provided` where as application/test modules to not have `Provided` and instead give the precise version.

# Why this way

Due to how Akka works with binary compatibility its recommended that libraries only provide the dependencies where as applications should provide the exact version.
