### PR TITLE
Renamed `MaxCleanupTimeout` to `maxCleanupTimeout`

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -82,7 +82,7 @@ trait BackupClientSpec
 
   /** The MaxTimeout when cleaning up all of the buckets during `afterAll`
     */
-  lazy val MaxCleanupTimeout: FiniteDuration = 10 minutes
+  lazy val maxCleanupTimeout: FiniteDuration = 10 minutes
 
   private def cleanBucket(bucket: String): Future[Unit] = (for {
     check <- S3.checkIfBucketExists(bucket)
@@ -123,7 +123,7 @@ trait BackupClientSpec
           Future.sequence(futures)
         }
 
-        Await.result(akka.pattern.after(initialDelay)(cleanAllBuckets), MaxCleanupTimeout)
+        Await.result(akka.pattern.after(initialDelay)(cleanAllBuckets), maxCleanupTimeout)
       case None => ()
     }
 


### PR DESCRIPTION
See https://github.com/aiven/guardian-for-apache-kafka/pull/65#discussion_r724134466