### PR TITLE
Add convenience method for converting Kafka future

### DIFF
--- a/core/src/test/scala/io/aiven/guardian/kafka/Utils.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/Utils.scala
@@ -1,0 +1,24 @@
+package io.aiven.guardian.kafka
+
+import org.apache.kafka.common.KafkaFuture
+
+import java.util.concurrent.CompletableFuture
+
+object Utils {
+
+  // Taken from https://stackoverflow.com/a/56763206/1519631
+  implicit final class KafkaFutureToCompletableFuture[T](kafkaFuture: KafkaFuture[T]) {
+    @SuppressWarnings(Array("DisableSyntax.null"))
+    def toCompletableFuture: CompletableFuture[T] = {
+      val wrappingFuture = new CompletableFuture[T]
+      kafkaFuture.whenComplete { (value, throwable) =>
+        if (throwable != null)
+          wrappingFuture.completeExceptionally(throwable)
+        else
+          wrappingFuture.complete(value)
+      }
+      wrappingFuture
+    }
+  }
+
+}


### PR DESCRIPTION
I forgot this in the previous PR at https://github.com/aiven/guardian-for-apache-kafka/pull/72, this is a convenience method that converts Kafka future's to Java `CompletableFuture` (which we can then convert to a Scala `Future` using `scala.jdk.FutureConverters`.