### PR TITLE
Replace unneeded throttle parameter with Source

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -7,6 +7,7 @@ import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
 import akka.testkit.TestKitBase
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMatcher.matchTo
@@ -131,11 +132,11 @@ trait BackupClientSpec
     forAll(kafkaDataWithTimePeriodsGen(), s3ConfigGen(useVirtualDotHost, bucketPrefix)) {
       (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
         logger.info(s"Data bucket is ${s3Config.dataBucket}")
-        val backupClient = new MockedS3BackupClientInterface(kafkaDataWithTimePeriod.data,
-                                                             kafkaDataWithTimePeriod.periodSlice,
-                                                             s3Config,
-                                                             Some(s3Settings),
-                                                             Some(_.throttle(ThrottleElements, ThrottleAmount))
+        val backupClient = new MockedS3BackupClientInterface(
+          Source(kafkaDataWithTimePeriod.data).throttle(ThrottleElements, ThrottleAmount),
+          kafkaDataWithTimePeriod.periodSlice,
+          s3Config,
+          Some(s3Settings)
         )
 
         val delay =

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
@@ -12,15 +12,12 @@ import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import scala.concurrent.duration.FiniteDuration
 
 class MockedS3BackupClientInterface(
-    kafkaData: List[ReducedConsumerRecord],
+    kafkaData: Source[ReducedConsumerRecord, NotUsed],
     periodSlice: FiniteDuration,
     s3Config: S3Config,
-    maybeS3Settings: Option[S3Settings],
-    sourceTransform: Option[
-      Source[(ReducedConsumerRecord, Long), NotUsed] => Source[(ReducedConsumerRecord, Long), NotUsed]
-    ] = None
+    maybeS3Settings: Option[S3Settings]
 )(implicit val s3Headers: S3Headers)
-    extends BackupClient(maybeS3Settings)(new MockedKafkaClientInterface(kafkaData, sourceTransform),
+    extends BackupClient(maybeS3Settings)(new MockedKafkaClientInterface(kafkaData),
                                           Backup(periodSlice),
                                           s3Config,
                                           implicitly

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -40,7 +40,7 @@ class BackupClientInterfaceSpec
 
   property("Ordered Kafka events should produce at least one BackupStreamPosition.Boundary") {
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(kafkaDataWithTimePeriod.data),
                                                                     kafkaDataWithTimePeriod.periodSlice
       )
 
@@ -61,7 +61,7 @@ class BackupClientInterfaceSpec
     "Every ReducedConsumerRecord after a BackupStreamPosition.Boundary should be in the next consecutive time period"
   ) {
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(kafkaDataWithTimePeriod.data),
                                                                     kafkaDataWithTimePeriod.periodSlice
       )
 
@@ -95,7 +95,7 @@ class BackupClientInterfaceSpec
     "The time difference between two consecutive BackupStreamPosition.Middle's has to be less then the specified time period"
   ) {
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(kafkaDataWithTimePeriod.data),
                                                                     kafkaDataWithTimePeriod.periodSlice
       )
 
@@ -121,7 +121,7 @@ class BackupClientInterfaceSpec
 
   property("backup method completes flow correctly for all valid Kafka events") {
     forAll(kafkaDataWithTimePeriodsGen()) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod) =>
-      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(kafkaDataWithTimePeriod.data,
+      val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(kafkaDataWithTimePeriod.data),
                                                                     kafkaDataWithTimePeriod.periodSlice
       )
 

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -1,9 +1,11 @@
 package io.aiven.guardian.kafka.backup
 
 import akka.Done
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import io.aiven.guardian.kafka.MockedKafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
@@ -78,6 +80,6 @@ class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafka
 
 /** A `MockedBackupClientInterface` that also uses a mocked `KafkaClientInterface`
   */
-class MockedBackupClientInterfaceWithMockedKafkaData(kafkaData: List[ReducedConsumerRecord],
+class MockedBackupClientInterfaceWithMockedKafkaData(kafkaData: Source[ReducedConsumerRecord, NotUsed],
                                                      periodSlice: FiniteDuration
 ) extends MockedBackupClientInterface(new MockedKafkaClientInterface(kafkaData), periodSlice)


### PR DESCRIPTION
This PR cleans up the parameters that are used in the various test mocks. Previously we had raw data, i.e. a `List[ReducedConsumerRecord]` along with a `throttle` parameter when needed (i.e. for real S3 tests) however this was overly engineered/complex as it turns out you can just have a `Source` parameter without the need of `throttle`. This change was also required when testing for the suspend/resume changes.