### PR TITLE
Implement CLI for backup

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -1,0 +1,24 @@
+package io.aiven.guardian.kafka.backup
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer
+import io.aiven.guardian.kafka.backup.BackupClientInterface
+import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaClientInterface
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+trait App[T <: KafkaClientInterface] {
+  implicit val kafkaClient: T
+  implicit val backupClient: BackupClientInterface[KafkaClient]
+  implicit val actorSystem: ActorSystem
+  implicit val executionContext: ExecutionContext
+
+  def run(): Consumer.Control = backupClient.backup.run()
+  def shutdown(control: Consumer.Control): Future[Done] =
+    // Ideally we should be using drainAndShutdown however this isn't possible due to
+    // https://github.com/aiven/guardian-for-apache-kafka/issues/80
+    control.stop().flatMap(_ => control.shutdown())
+}

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupApp.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupApp.scala
@@ -1,0 +1,10 @@
+package io.aiven.guardian.kafka.backup
+
+import io.aiven.guardian.cli.AkkaSettings
+import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.{Config => BackupConfig}
+import io.aiven.guardian.kafka.{Config => KafkaConfig}
+
+trait BackupApp extends BackupConfig with KafkaConfig with AkkaSettings {
+  implicit lazy val kafkaClient: KafkaClient = new KafkaClient()
+}

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -1,0 +1,101 @@
+package io.aiven.guardian.kafka.backup
+
+import akka.kafka.ConsumerSettings
+import cats.implicits._
+import com.monovore.decline._
+import io.aiven.guardian.cli.arguments.StorageOpt
+import io.aiven.guardian.cli.options.Options
+import io.aiven.guardian.kafka.backup.configs.Backup
+import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
+import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
+import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
+import io.aiven.guardian.kafka.configs.KafkaCluster
+import io.aiven.guardian.kafka.s3.configs.S3
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class Entry(val initializedApp: AtomicReference[Option[App[_]]] = new AtomicReference(None))
+    extends CommandApp(
+      name = "guardian-backup",
+      header = "Guardian cli Backup Tool",
+      main = {
+        val groupIdOpt: Opts[Option[String]] =
+          Opts.option[String]("kafka-group-id", help = "Kafka group id for the consumer").orNone
+
+        val periodFromFirstOpt =
+          Opts
+            .option[FiniteDuration]("period-from-first", help = "Duration for period-from-first configured backup")
+            .map(PeriodFromFirst.apply)
+
+        val chronoUnitSliceOpt =
+          Opts
+            .option[ChronoUnit]("chrono-unit-slice", help = "ChronoUnit for chrono-unit-slice configured backup")
+            .map(ChronoUnitSlice.apply)
+
+        val timeConfigurationOpt: Opts[Option[TimeConfiguration]] =
+          (periodFromFirstOpt orElse chronoUnitSliceOpt).orNone
+
+        val backupOpt =
+          (groupIdOpt, timeConfigurationOpt).tupled.mapValidated { case (maybeGroupId, maybeTimeConfiguration) =>
+            import io.aiven.guardian.kafka.backup.Config.backupConfig
+            (maybeGroupId, maybeTimeConfiguration) match {
+              case (Some(groupId), Some(timeConfiguration)) =>
+                Backup(groupId, timeConfiguration).validNel
+              case _ =>
+                Options
+                  .optionalPureConfigValue(() => backupConfig)
+                  .toValidNel("Backup config is a mandatory value that needs to be configured")
+            }
+          }
+
+        val s3Opt = Options.dataBucketOpt.mapValidated { maybeDataBucket =>
+          import io.aiven.guardian.kafka.s3.Config
+          maybeDataBucket match {
+            case Some(value) => S3(dataBucket = value).validNel
+            case _ =>
+              Options
+                .optionalPureConfigValue(() => Config.s3Config)
+                .toValidNel("S3 data bucket is a mandatory value that needs to be configured")
+          }
+        }
+
+        val kafkaConsumerSettingsOpt
+            : Opts[Option[ConsumerSettings[Array[Byte], Array[Byte]] => ConsumerSettings[Array[Byte], Array[Byte]]]] =
+          Options.bootstrapServersOpt.mapValidated {
+            case Some(value) =>
+              val block =
+                (block: ConsumerSettings[Array[Byte], Array[Byte]]) =>
+                  block.withBootstrapServers(value.toList.mkString(","))
+
+              Some(block).validNel
+            case None if Options.checkConfigKeyIsDefined("kafka-client.bootstrap.servers") => None.validNel
+            case _ => "bootstrap-servers is a mandatory value that needs to be configured".invalidNel
+          }
+
+        (Options.storageOpt, Options.kafkaClusterOpt, kafkaConsumerSettingsOpt, s3Opt, backupOpt).mapN {
+          (storage, kafkaCluster, kafkaConsumerSettings, s3, backup) =>
+            val app = storage match {
+              case StorageOpt.S3 =>
+                new S3App {
+                  override lazy val kafkaClusterConfig: KafkaCluster = kafkaCluster
+                  override lazy val s3Config: S3                     = s3
+                  override lazy val backupConfig: Backup             = backup
+                  override lazy val kafkaClient: KafkaClient =
+                    new KafkaClient(kafkaConsumerSettings)(actorSystem, kafkaClusterConfig, backupConfig)
+                }
+            }
+            initializedApp.set(Some(app))
+            val control = app.run()
+            Runtime.getRuntime.addShutdownHook(new Thread {
+              Await.result(app.shutdown(control), 5 minutes)
+            })
+        }
+      }
+    )
+
+object Main extends Entry()

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/S3App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/S3App.scala
@@ -1,0 +1,11 @@
+package io.aiven.guardian.kafka.backup
+
+import akka.stream.alpakka.s3.S3Settings
+import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.s3.BackupClient
+import io.aiven.guardian.kafka.s3.{Config => S3Config}
+
+trait S3App extends S3Config with BackupApp with App[KafkaClient] {
+  lazy val s3Settings: S3Settings                           = S3Settings()
+  implicit lazy val backupClient: BackupClient[KafkaClient] = new BackupClient[KafkaClient](Some(s3Settings))
+}

--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
@@ -1,0 +1,48 @@
+package io.aiven.guardian.kafka
+
+import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
+import io.aiven.guardian.kafka.backup.configs.{Backup => BackupConfig}
+import io.aiven.guardian.kafka.configs.{KafkaCluster => KafkaClusterConfig}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import scala.annotation.nowarn
+
+import java.time.temporal.ChronoUnit
+
+@nowarn("msg=method main in class CommandApp is deprecated")
+class CliSpec extends AnyPropSpec with Matchers {
+
+  property("Command line args are properly passed into application") {
+    val groupId         = "my-consumer-group"
+    val topic           = "topic"
+    val bootstrapServer = "localhost:9092"
+    val dataBucket      = "backup-bucket"
+
+    val args = List(
+      "--storage",
+      "s3",
+      "--kafka-topics",
+      topic,
+      "--kafka-bootstrap-servers",
+      bootstrapServer,
+      "--s3-data-bucket",
+      dataBucket,
+      "--kafka-group-id",
+      groupId,
+      "--chrono-unit-slice",
+      "hours"
+    )
+
+    backup.Main.main(args.toArray)
+    backup.Main.initializedApp.get() match {
+      case Some(s3App: backup.S3App) =>
+        s3App.backupConfig mustEqual BackupConfig(groupId, ChronoUnitSlice(ChronoUnit.HOURS))
+        s3App.kafkaClusterConfig mustEqual KafkaClusterConfig(Set(topic))
+        s3App.kafkaClient.consumerSettings.getProperty("bootstrap.servers") mustEqual bootstrapServer
+        s3App.s3Config.dataBucket mustEqual dataBucket
+      case _ =>
+    }
+  }
+
+}

--- a/core-cli/src/main/resources/application.conf
+++ b/core-cli/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "INFO"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}

--- a/core-cli/src/main/resources/logback.xml
+++ b/core-cli/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%highlight(%-5level)] %logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+
+</configuration>

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/AkkaSettings.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/AkkaSettings.scala
@@ -1,0 +1,10 @@
+package io.aiven.guardian.cli
+
+import akka.actor.ActorSystem
+
+import scala.concurrent.ExecutionContext
+
+trait AkkaSettings {
+  implicit val actorSystem: ActorSystem           = ActorSystem()
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+}

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/arguments/StorageOpt.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/arguments/StorageOpt.scala
@@ -1,0 +1,22 @@
+package io.aiven.guardian.cli.arguments
+
+import cats.data.ValidatedNel
+import cats.implicits._
+import com.monovore.decline.Argument
+import enumeratum._
+
+sealed trait StorageOpt extends EnumEntry with EnumEntry.Lowercase
+
+object StorageOpt extends Enum[StorageOpt] {
+  case object S3 extends StorageOpt
+
+  val values: IndexedSeq[StorageOpt] = findValues
+
+  implicit val storageArgument: Argument[StorageOpt] = new Argument[StorageOpt] {
+    override def read(string: String): ValidatedNel[String, StorageOpt] =
+      StorageOpt.withNameOption(string).toValidNel("Invalid Storage Argument")
+
+    override def defaultMetavar: String = "storage"
+  }
+
+}

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
@@ -1,0 +1,56 @@
+package io.aiven.guardian.cli.options
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import com.monovore.decline.Opts
+import com.typesafe.config.ConfigException.Missing
+import com.typesafe.config.ConfigFactory
+import io.aiven.guardian.cli.arguments.StorageOpt
+import io.aiven.guardian.kafka.configs.KafkaCluster
+import pureconfig.error.ConfigReaderException
+
+trait Options {
+  val storageOpt: Opts[StorageOpt] =
+    Opts.option[StorageOpt]("storage", help = "Which type of storage to persist kafka topics")
+
+  val dataBucketOpt: Opts[Option[String]] =
+    Opts.option[String]("s3-data-bucket", help = "S3 Bucket for storage of main backup data").orNone
+
+  val topicsOpt: Opts[Option[NonEmptyList[String]]] =
+    Opts.options[String]("kafka-topics", help = "Kafka topics to backup").orNone
+
+  val bootstrapServersOpt: Opts[Option[NonEmptyList[String]]] =
+    Opts.options[String]("kafka-bootstrap-servers", help = "Kafka bootstrap servers").orNone
+
+  def optionalPureConfigValue[T](value: () => T): Option[T] =
+    try Some(value())
+    catch {
+      case _: ConfigReaderException[_] =>
+        None
+    }
+
+  @SuppressWarnings(
+    Array(
+      "scalafix:DisableSyntax.null"
+    )
+  )
+  def checkConfigKeyIsDefined(path: String): Boolean =
+    try ConfigFactory.load().getAnyRef(path) != null
+    catch {
+      case _: Missing => false
+    }
+
+  val kafkaClusterOpt: Opts[KafkaCluster] = topicsOpt.mapValidated { topics =>
+    import io.aiven.guardian.kafka.{Config => KafkaConfig}
+    topics match {
+      case Some(value) =>
+        KafkaCluster(value.toList.toSet).validNel
+      case None if KafkaConfig.kafkaClusterConfig.topics.nonEmpty => KafkaConfig.kafkaClusterConfig.validNel
+      case _ =>
+        "kafka-topics is a mandatory value that needs to be configured".invalidNel
+    }
+  }
+
+}
+
+object Options extends Options

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -27,6 +27,10 @@ akka.kafka.consumer = {
     }
 }
 
+kafka-client = {
+    bootstrap.servers = ${?KAFKA_CLIENT_BOOTSTRAP_SERVERS}
+}
+
 akka.kafka.committer = {
     max-batch = 100000
     max-batch = ${?AKKA_KAFKA_COMMITTER_MAX_BATCH}


### PR DESCRIPTION
# About this change - What it does

This change implements basic CLI interface for the backup client

# Why this way

This PR ultimately adds in CLI capability for the guardian backup tool, allowing you to both pass in command line arguments into guardian-backup as well as allowing you to package the tool into various formats. Ideally I would have liked to also create a native image using graalvm but it turns out using graalvm with akka ecosystem doesn't appear to be that well support (mainly due to reflection reasons) but even basic things such as logback causes problems for the same reason so I will leave this for now.

The PR also adds standard basic configuration, i.e. a `logback.xml` so you can see basic logs as well as configuring akka to log through that logback.

A basic smoke style test has also been created where we pass cli command line arguments into the app and we check that the configuration setttings correctly passed into the application (note that we are not doing an end2end test because thats the job of other modules).

In terms of publishing formats currently rpm and java `.zip` formats are supported. Support for other formats like docker can also be done but to make this PR smaller we can handle this later.

Note that not all settings have been configured via CLI. This is due to valuing my sanity because of the sheer amount of things that can be configured via environment variables. Some configurations such as `S3Settings` which store S3 region/secret/access can also be somewhat reasonably argued should also be configurable by CLI but this improvement can be done for a later PR.