### PR TITLE
Restructure kafka client into backup

### DIFF
--- a/backup-gcs/src/main/scala/io/aiven/guardian/kafka/backup/gcs/BackupClient.scala
+++ b/backup-gcs/src/main/scala/io/aiven/guardian/kafka/backup/gcs/BackupClient.scala
@@ -8,8 +8,8 @@ import akka.stream.alpakka.googlecloud.storage.StorageObject
 import akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
-import io.aiven.guardian.kafka.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.BackupClientInterface
+import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.gcs.configs.{GCS => GCSConfig}
 

--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -15,8 +15,8 @@ import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
-import io.aiven.guardian.kafka.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.BackupClientInterface
+import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientChunkState.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientChunkState.scala
@@ -6,7 +6,7 @@ import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.SuccessfulUploadPart
 import akka.stream.scaladsl.Sink
-import io.aiven.guardian.kafka.KafkaClientInterface
+import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaClientWithKillSwitch.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaClientWithKillSwitch.scala
@@ -7,7 +7,7 @@ import akka.kafka.ConsumerSettings
 import akka.kafka.scaladsl.Consumer
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.SourceWithContext
-import io.aiven.guardian.kafka.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaClient
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaClientWithKillSwitch.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaClientWithKillSwitch.scala
@@ -8,6 +8,7 @@ import akka.kafka.scaladsl.Consumer
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.SourceWithContext
 import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 
@@ -19,7 +20,7 @@ class KafkaClientWithKillSwitch(
       CommitterSettings => CommitterSettings
     ] = None,
     killSwitch: SharedKillSwitch
-)(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster)
+)(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster, backupConfig: Backup)
     extends KafkaClient(configureConsumer, configureCommitter) {
   override def getSource
       : SourceWithContext[ReducedConsumerRecord, ConsumerMessage.CommittableOffset, Consumer.Control] =

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.scaladsl.Source
+import io.aiven.guardian.kafka.backup.MockedBackupClientInterface
 import io.aiven.guardian.kafka.backup.MockedKafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
@@ -18,7 +19,7 @@ class MockedS3BackupClientInterface(
     maybeS3Settings: Option[S3Settings]
 )(implicit val s3Headers: S3Headers, system: ActorSystem)
     extends BackupClient(maybeS3Settings)(new MockedKafkaClientInterface(kafkaData),
-                                          Backup(timeConfiguration),
+                                          Backup(MockedBackupClientInterface.KafkaGroupId, timeConfiguration),
                                           implicitly,
                                           s3Config,
                                           implicitly

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorSystem
 import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.scaladsl.Source
-import io.aiven.guardian.kafka.MockedKafkaClientInterface
+import io.aiven.guardian.kafka.backup.MockedKafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -17,9 +17,9 @@ import com.softwaremill.diffx.scalatest.DiffMustMatcher._
 import io.aiven.guardian.akka.AnyPropTestKit
 import io.aiven.guardian.kafka.Generators.KafkaDataInChunksWithTimePeriod
 import io.aiven.guardian.kafka.Generators.kafkaDataWithMinSizeGen
-import io.aiven.guardian.kafka.KafkaClient
 import io.aiven.guardian.kafka.KafkaClusterTest
 import io.aiven.guardian.kafka.Utils._
+import io.aiven.guardian.kafka.backup.KafkaClient
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -20,6 +20,7 @@ import io.aiven.guardian.kafka.Generators.kafkaDataWithMinSizeGen
 import io.aiven.guardian.kafka.KafkaClusterTest
 import io.aiven.guardian.kafka.Utils._
 import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.MockedBackupClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
@@ -73,12 +74,12 @@ class RealS3BackupClientSpec
     Some(
       _.withBootstrapServers(
         container.bootstrapServers
-      ).withGroupId("test-group")
+      )
     )
 
   def createKafkaClient(
       killSwitch: SharedKillSwitch
-  )(implicit kafkaClusterConfig: KafkaCluster): KafkaClientWithKillSwitch =
+  )(implicit kafkaClusterConfig: KafkaCluster, backupConfig: Backup): KafkaClientWithKillSwitch =
     new KafkaClientWithKillSwitch(
       configureConsumer = baseKafkaConfig,
       killSwitch = killSwitch
@@ -173,7 +174,7 @@ class RealS3BackupClientSpec
       implicit val kafkaClusterConfig: KafkaCluster = KafkaCluster(topics)
 
       implicit val config: S3Config     = s3Config
-      implicit val backupConfig: Backup = Backup(PeriodFromFirst(1 minute))
+      implicit val backupConfig: Backup = Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute))
 
       val producerSettings = createProducer()
 
@@ -253,8 +254,9 @@ class RealS3BackupClientSpec
 
       implicit val kafkaClusterConfig: KafkaCluster = KafkaCluster(topics)
 
-      implicit val config: S3Config     = s3Config
-      implicit val backupConfig: Backup = Backup(ChronoUnitSlice(ChronoUnit.MINUTES))
+      implicit val config: S3Config = s3Config
+      implicit val backupConfig: Backup =
+        Backup(MockedBackupClientInterface.KafkaGroupId, ChronoUnitSlice(ChronoUnit.MINUTES))
 
       val producerSettings = createProducer()
 

--- a/core-backup/src/main/resources/reference.conf
+++ b/core-backup/src/main/resources/reference.conf
@@ -1,4 +1,5 @@
 backup {
+    kafka-group-id = ${?BACKUP_KAFKA_GROUP_ID}
     time-configuration = {
        type = chrono-unit-slice
        type = ${?BACKUP_TIME_CONFIGURATION_TYPE}

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl._
 import akka.util.ByteString
 import io.aiven.guardian.kafka.Errors
-import io.aiven.guardian.kafka.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -1,4 +1,4 @@
-package io.aiven.guardian.kafka
+package io.aiven.guardian.kafka.backup
 
 import akka.Done
 import akka.actor.ActorSystem

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -13,6 +13,7 @@ import akka.kafka.scaladsl.Consumer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.SourceWithContext
 import com.typesafe.scalalogging.StrictLogging
+import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -42,7 +43,7 @@ class KafkaClient(
     configureCommitter: Option[
       CommitterSettings => CommitterSettings
     ] = None
-)(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster)
+)(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster, backupConfig: Backup)
     extends KafkaClientInterface
     with StrictLogging {
   override type CursorContext        = CommittableOffset
@@ -58,6 +59,9 @@ class KafkaClient(
       .fold(base)(block => block(base))
       .withProperties(
         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest"
+      )
+      .withGroupId(
+        backupConfig.kafkaGroupId
       )
   }
 

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClientInterface.scala
@@ -1,4 +1,4 @@
-package io.aiven.guardian.kafka
+package io.aiven.guardian.kafka.backup
 
 import akka.Done
 import akka.stream.scaladsl.Sink

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
@@ -1,6 +1,8 @@
 package io.aiven.guardian.kafka.backup.configs
 
-/** @param timeConfiguration
+/** @param kafkaGroupId
+  *   The group-id that the Kafka consumer will use
+  * @param timeConfiguration
   *   Determines how the backed up objects/files are segregated depending on a time configuration
   */
-final case class Backup(timeConfiguration: TimeConfiguration)
+final case class Backup(kafkaGroupId: String, timeConfiguration: TimeConfiguration)

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -28,6 +28,8 @@ class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafka
 )(implicit override val system: ActorSystem)
     extends BackupClientInterface[MockedKafkaClientInterface] {
 
+  import MockedBackupClientInterface._
+
   /** The collection that receives the data as its being submitted where each value is the key along with the
     * `ByteString`. Use `mergeBackedUpData` to process `backedUpData` into a more convenient data structure once you
     * have finished writing to it
@@ -72,6 +74,7 @@ class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafka
   def clear(): Unit = backedUpData.clear()
 
   override implicit lazy val backupConfig: Backup = Backup(
+    KafkaGroupId,
     timeConfiguration
   )
 
@@ -105,6 +108,14 @@ class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafka
     calculateBackupStreamPositions(sourceWithPeriods(sourceWithFirstRecord))
       .toMat(Sink.collection)(Keep.right)
       .run()
+}
+
+object MockedBackupClientInterface {
+
+  /** A Kafka group id that is used in testing. When used in pure mocks this value is simply ignored (since there is no
+    * Kafka cluster) where as when used against actual test Kafka clusters this is the consumer group that is used
+    */
+  val KafkaGroupId: String = "test"
 }
 
 /** A `MockedBackupClientInterface` that also uses a mocked `KafkaClientInterface`

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -7,7 +7,6 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import io.aiven.guardian.kafka.MockedKafkaClientInterface
 import io.aiven.guardian.kafka.Utils._
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.TimeConfiguration

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
@@ -1,4 +1,4 @@
-package io.aiven.guardian.kafka
+package io.aiven.guardian.kafka.backup
 
 import akka.Done
 import akka.NotUsed

--- a/core-s3/src/main/resources/reference.conf
+++ b/core-s3/src/main/resources/reference.conf
@@ -2,16 +2,15 @@ alpakka.s3 {
   buffer = ${?ALPAKKA_S3_BUFFER}
   disk-buffer-path = ${?ALPAKKA_S3_DISK_BUFFER_PATH}
 
-# This is disabled due to https://github.com/akka/alpakka/pull/2720
-#   forward-proxy {
-#     scheme = ${?ALPAKKA_S3_FORWARD_PROXY_SCHEME}
-#     host = ${?ALPAKKA_S3_FORWARD_PROXY_HOST}
-#     port = ${?ALPAKKA_S3_FORWARD_PROXY_PORT}
-#     credentials {
-#       username = ${?ALPAKKA_S3_FORWARD_PROXY_CREDENTIALS_USERNAME}
-#       password = ${?ALPAKKA_S3_FORWARD_PROXY_CREDENTIALS_PASSWORD}
-#     }
-#   }
+  forward-proxy {
+    scheme = ${?ALPAKKA_S3_FORWARD_PROXY_SCHEME}
+    host = ${?ALPAKKA_S3_FORWARD_PROXY_HOST}
+    port = ${?ALPAKKA_S3_FORWARD_PROXY_PORT}
+    credentials {
+      username = ${?ALPAKKA_S3_FORWARD_PROXY_CREDENTIALS_USERNAME}
+      password = ${?ALPAKKA_S3_FORWARD_PROXY_CREDENTIALS_PASSWORD}
+    }
+  }
 
   aws {
     credentials {
@@ -50,6 +49,4 @@ s3-headers = {
 s3-config = {
     data-bucket = ${?S3_CONFIG_DATA_BUCKET}
     data-bucket-prefix = ${?S3_CONFIG_DATA_BUCKET_PREFIX}
-    compaction-bucket = ${?S3_CONFIG_COMPACTION_BUCKET}
-    compaction-bucket-prefix = ${?S3_CONFIG_COMPACTION_BUCKET_PREFIX}
 }

--- a/core-s3/src/main/scala/io/aiven/guardian/kafka/s3/configs/S3.scala
+++ b/core-s3/src/main/scala/io/aiven/guardian/kafka/s3/configs/S3.scala
@@ -5,17 +5,9 @@ package io.aiven.guardian.kafka.s3.configs
   *   The bucket where a Kafka Consumer directly streams data into as storage
   * @param dataBucketPrefix
   *   Prefix for the data bucket (if any)
-  * @param compactionBucket
-  *   The bucket where compaction results are stored
-  * @param compactionBucketPrefix
-  *   Prefix for the compaction bucket (if any)
   */
-final case class S3(dataBucket: String,
-                    dataBucketPrefix: Option[String],
-                    compactionBucket: String,
-                    compactionBucketPrefix: Option[String]
-)
+final case class S3(dataBucket: String, dataBucketPrefix: Option[String])
 
 object S3 {
-  def apply(dataBucket: String, compactionBucket: String): S3 = S3(dataBucket, None, compactionBucket, None)
+  def apply(dataBucket: String): S3 = S3(dataBucket, None)
 }

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Generators.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Generators.scala
@@ -108,9 +108,8 @@ object Generators {
     } yield bucketName
   }
 
-  def s3ConfigGen(useVirtualDotHost: Boolean, prefix: Option[String] = None): Gen[S3Config] = (for {
-    dataBucket       <- bucketNameGen(useVirtualDotHost, prefix)
-    compactionBucket <- bucketNameGen(useVirtualDotHost, prefix)
-  } yield S3Config(dataBucket, compactionBucket)).filter(config => config.dataBucket != config.compactionBucket)
+  def s3ConfigGen(useVirtualDotHost: Boolean, prefix: Option[String] = None): Gen[S3Config] = for {
+    dataBucket <- bucketNameGen(useVirtualDotHost, prefix)
+  } yield S3Config(dataBucket)
 
 }


### PR DESCRIPTION
# About this change - What it does
This PR restructures some of the components in Guardian so that the dependencies are minimized. This is mainly a result of working on https://github.com/aiven/guardian-for-apache-kafka/pull/83, as it turns there are configurations/components which are mandatory that shouldn't be, or are in the wrong module.

Regarding the cli feature, without this PR we run into the problem where we are forced to write configurations which dont make sense (i.e. `compaction-bucket` for backup) or in other cases we there is no configuration for options we do need to provide (i.e. `group-id`)

# Why this way

The PR is split into 3 commits, each complaining the reasoning behind the change

* `Move KafkaClient into core-backup`: `KafkaClient` is a KafkaConsumer that listens to a Kafka cluster, strictly speaking this functionality is only needed for backing up of data hence why it was moved to `core-backup` instead of just `core`. One of the reasons behind this change was the fact that certain Kafka configurations such as `bootstrap-servers` are global for every component but others such as `group-id` (aka consumer group) only exist for Kafka consumers and not producers (i.e. restore).
* `Add kafka-group-id config into Backup config`: This adds `group-id` configuration as a core config into the `backup-core` `Backup` configuration. Interestingly Kafka configuration with alpakka is all over the place, some configurations such as `bootstrap-servers` have a default config in `reference.conf` that can be overridden, others such as `group-id` have no Typesafe configuration at all. Since there is no non-programmatic way to configure `group-id` we added it into our own config.
* `Remove compaction-bucket config from core-s3`: This configuration was placed into the wrong project, it should rather belong in `compaction-s3`/`restore-s3` since thats the only place where this bucket will be used. Note that only the `S3` case class that is serialized from the typesafe config had the configuration option removed, the path for the `compaction-bucket` will still be contained within the `s3-config` path in `reference.conf` its just that the config will be placed in the `reference.conf` of other projects (and this will work fine since typesafe config naturally supports merging of configs).
