### PR TITLE
Use JSON Array streaming in tests

### DIFF
--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -17,6 +17,7 @@ import org.scalatest.Inspectors
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.jawn.AsyncParser
 
 import scala.annotation.nowarn
 import scala.concurrent.ExecutionContext
@@ -130,16 +131,13 @@ class BackupClientInterfaceSpec
           asRecords <- Future.sequence(processedRecords.map { case (key, byteString) =>
                          Source
                            .single(byteString)
-                           .via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]])
+                           .via(CirceStreamSupport.decode[Option[ReducedConsumerRecord]](AsyncParser.UnwrapArray))
+                           .collect { case Some(value) =>
+                             value
+                           }
                            .toMat(Sink.collection)(Keep.right)
                            .run()
-                           .map(records =>
-                             (key,
-                              records.flatten.collect { case Some(v) =>
-                                v
-                              }
-                             )
-                           )
+                           .map(records => (key, records))
                        })
         } yield asRecords
 
@@ -173,16 +171,13 @@ class BackupClientInterfaceSpec
           asRecords <- Future.sequence(processedRecords.map { case (key, byteString) =>
                          Source
                            .single(byteString)
-                           .via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]])
+                           .via(CirceStreamSupport.decode[Option[ReducedConsumerRecord]](AsyncParser.UnwrapArray))
+                           .collect { case Some(value) =>
+                             value
+                           }
                            .toMat(Sink.collection)(Keep.right)
                            .run()
-                           .map(records =>
-                             (key,
-                              records.flatten.collect { case Some(v) =>
-                                v
-                              }
-                             )
-                           )
+                           .map(records => (key, records))
                        })
         } yield asRecords
 
@@ -210,16 +205,13 @@ class BackupClientInterfaceSpec
       asRecords <- Future.sequence(processedRecords.map { case (key, byteString) =>
                      Source
                        .single(byteString)
-                       .via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]])
+                       .via(CirceStreamSupport.decode[Option[ReducedConsumerRecord]](AsyncParser.UnwrapArray))
+                       .collect { case Some(value) =>
+                         value
+                       }
                        .toMat(Sink.collection)(Keep.right)
                        .run()
-                       .map(records =>
-                         (key,
-                          records.flatten.collect { case Some(v) =>
-                            v
-                          }
-                         )
-                       )
+                       .map(records => (key, records))
                    })
     } yield asRecords
 
@@ -249,16 +241,13 @@ class BackupClientInterfaceSpec
       asRecords <- Future.sequence(processedRecords.map { case (key, byteString) =>
                      Source
                        .single(byteString)
-                       .via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]])
+                       .via(CirceStreamSupport.decode[Option[ReducedConsumerRecord]](AsyncParser.UnwrapArray))
+                       .collect { case Some(value) =>
+                         value
+                       }
                        .toMat(Sink.collection)(Keep.right)
                        .run()
-                       .map(records =>
-                         (key,
-                          records.flatten.collect { case Some(v) =>
-                            v
-                          }
-                         )
-                       )
+                       .map(records => (key, records))
                    })
     } yield asRecords
 


### PR DESCRIPTION
# About this change - What it does

This change implements actual JSON streaming for each individual element of the array rather than streaming it in all at once. 

# Why this way

Even though we are using akka-streams-json which is a streaming JSON parser, if you use it in its default configuration the streaming will just apply to the underlying `ByteString`. In order to get the behaviour we want where we stream each individual element in the JSON array rather than parsing it in all at once we need to use the `AsyncParser.UnwrapArray`.

This PR only updates the tests but since the actual restore will be using the same parsing mode we should make sure it works this way. As a bonus this should reduce some of the GC/memory pressure in the tests, since we are actually streaming the individual JSON elements as intended