### PR TITLE
Add partition to ReducedConsumerRecord

### DIFF
--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -106,6 +106,7 @@ object KafkaClient {
   ): ReducedConsumerRecord =
     ReducedConsumerRecord(
       consumerRecord.topic(),
+      consumerRecord.partition(),
       consumerRecord.offset(),
       Base64.getEncoder.encodeToString(consumerRecord.key()),
       Base64.getEncoder.encodeToString(consumerRecord.value()),

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -190,7 +190,7 @@ class BackupClientInterfaceSpec
   }
 
   property("backup method completes flow correctly for single element") {
-    val reducedConsumerRecord = ReducedConsumerRecord("", 1, "key", "value", 1, TimestampType.CREATE_TIME)
+    val reducedConsumerRecord = ReducedConsumerRecord("", 0, 1, "key", "value", 1, TimestampType.CREATE_TIME)
 
     val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source.single(
                                                                     reducedConsumerRecord
@@ -224,8 +224,8 @@ class BackupClientInterfaceSpec
 
   property("backup method completes flow correctly for two elements") {
     val reducedConsumerRecords = List(
-      ReducedConsumerRecord("", 1, "key", "value1", 1, TimestampType.CREATE_TIME),
-      ReducedConsumerRecord("", 2, "key", "value2", 2, TimestampType.CREATE_TIME)
+      ReducedConsumerRecord("", 0, 1, "key", "value1", 1, TimestampType.CREATE_TIME),
+      ReducedConsumerRecord("", 0, 2, "key", "value2", 2, TimestampType.CREATE_TIME)
     )
 
     val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(

--- a/core/src/main/scala/io/aiven/guardian/kafka/codecs/Circe.scala
+++ b/core/src/main/scala/io/aiven/guardian/kafka/codecs/Circe.scala
@@ -16,8 +16,9 @@ trait Circe {
 
   implicit val kafkaTimestampTypeEncoder: Encoder[TimestampType] = Encoder.instance[TimestampType](_.id.asJson)
 
-  implicit val reducedConsumerRecordDecoder: Decoder[ReducedConsumerRecord] = Decoder.forProduct6(
+  implicit val reducedConsumerRecordDecoder: Decoder[ReducedConsumerRecord] = Decoder.forProduct7(
     "topic",
+    "partition",
     "offset",
     "key",
     "value",
@@ -25,8 +26,9 @@ trait Circe {
     "timestamp_type"
   )(ReducedConsumerRecord.apply)
 
-  implicit val reducedConsumerRecordEncoder: Encoder[ReducedConsumerRecord] = Encoder.forProduct6(
+  implicit val reducedConsumerRecordEncoder: Encoder[ReducedConsumerRecord] = Encoder.forProduct7(
     "topic",
+    "partition",
     "offset",
     "key",
     "value",

--- a/core/src/main/scala/io/aiven/guardian/kafka/models/ReducedConsumerRecord.scala
+++ b/core/src/main/scala/io/aiven/guardian/kafka/models/ReducedConsumerRecord.scala
@@ -22,6 +22,7 @@ import java.time.ZoneId
   *   The timestamp type (same as `ConsumerRecord` `timestampType`)
   */
 final case class ReducedConsumerRecord(topic: String,
+                                       partition: Int,
                                        offset: Long,
                                        key: String,
                                        value: String,

--- a/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
@@ -19,7 +19,8 @@ object Generators {
                                    key: String,
                                    timestamp: Long
   ): Gen[ReducedConsumerRecord] = for {
-    t             <- Gen.const(topic)
+    t <- Gen.const(topic)
+    p <- Gen.const(0) // In mocks this value is irrelevant and in tests we always have a single partition
     o             <- Gen.const(offset)
     k             <- Gen.const(key)
     value         <- Gen.alphaStr.map(string => Base64.getEncoder.encodeToString(string.getBytes))
@@ -27,6 +28,7 @@ object Generators {
     timestampType <- Gen.const(TimestampType.CREATE_TIME)
   } yield ReducedConsumerRecord(
     t,
+    p,
     o,
     k,
     value,


### PR DESCRIPTION
# About this change - What it does

This PR adds `partition` field to `ReducedConsumerRecord`

# Why this way

When using Kafka transactional API to restore a backup we need the original partition and it will likely be required for a working implementation of https://github.com/aiven/guardian-for-apache-kafka/pull/96