### PR TITLE
Implement CLI for restore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val restoreGCS = project
     librarySettings,
     name := s"$baseName-restore-gcs"
   )
-  .dependsOn(coreRestore, coreGCS)
+  .dependsOn(coreRestore % "compile->compile;test->test", coreGCS % "compile->compile;test->test")
 
 lazy val cliRestore = project
   .in(file("cli-restore"))
@@ -252,7 +252,10 @@ lazy val cliRestore = project
     cliSettings,
     name := s"$baseName-cli-restore"
   )
-  .dependsOn(coreCli, restoreS3, restoreGCS)
+  .dependsOn(coreCli    % "compile->compile;test->test",
+             restoreS3  % "compile->compile;test->test",
+             restoreGCS % "compile->compile;test->test"
+  )
   .enablePlugins(JavaAppPackaging)
 
 // This is currently causing problems, see https://github.com/djspiewak/sbt-github-actions/issues/74

--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
@@ -34,7 +34,10 @@ class CliSpec extends AnyPropSpec with Matchers {
       "hours"
     )
 
-    backup.Main.main(args.toArray)
+    try backup.Main.main(args.toArray)
+    catch {
+      case _: Throwable =>
+    }
     backup.Main.initializedApp.get() match {
       case Some(s3App: backup.S3App) =>
         s3App.backupConfig mustEqual BackupConfig(groupId, ChronoUnitSlice(ChronoUnit.HOURS))
@@ -42,6 +45,7 @@ class CliSpec extends AnyPropSpec with Matchers {
         s3App.kafkaClient.consumerSettings.getProperty("bootstrap.servers") mustEqual bootstrapServer
         s3App.s3Config.dataBucket mustEqual dataBucket
       case _ =>
+        fail("Expected an App to be initialized")
     }
   }
 

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/App.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/App.scala
@@ -1,0 +1,18 @@
+package io.aiven.guardian.kafka.restore
+
+import akka.Done
+import akka.actor.ActorSystem
+import io.aiven.guardian.kafka.restore.KafkaProducer
+import io.aiven.guardian.kafka.restore.s3.RestoreClient
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+trait App {
+  implicit val kafkaProducer: KafkaProducer
+  implicit val restoreClient: RestoreClient[KafkaProducer]
+  implicit val actorSystem: ActorSystem
+  implicit val executionContext: ExecutionContext
+
+  def run(): Future[Done] = restoreClient.restore
+}

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/Entry.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/Entry.scala
@@ -1,0 +1,135 @@
+package io.aiven.guardian.kafka.restore
+
+import akka.kafka.ProducerSettings
+import akka.stream.KillSwitches
+import akka.stream.SharedKillSwitch
+import cats.data.ValidatedNel
+import cats.implicits._
+import com.monovore.decline._
+import com.monovore.decline.time._
+import io.aiven.guardian.cli.arguments.StorageOpt
+import io.aiven.guardian.cli.options.Options
+import io.aiven.guardian.kafka.configs.KafkaCluster
+import io.aiven.guardian.kafka.restore.configs.Restore
+import io.aiven.guardian.kafka.s3.configs.S3
+import org.apache.kafka.clients.producer.ProducerConfig
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicReference
+
+class Entry(val initializedApp: AtomicReference[Option[App]] = new AtomicReference(None))
+    extends CommandApp(
+      name = "guardian-restore",
+      header = "Guardian cli Backup Tool",
+      main = {
+        val fromWhenOpt: Opts[Option[OffsetDateTime]] =
+          Opts.option[OffsetDateTime]("from-when", help = "Only restore topics from a given time").orNone
+
+        val topicNameMapArgument: Opts[Option[Map[String, String]]] = {
+
+          val colonTupleArgument = new Argument[(String, String)] {
+            override def read(string: String): ValidatedNel[String, (String, String)] =
+              string.split(":") match {
+                case Array(left, right) => (left, right).validNel
+                case _                  => "Expected a colon delimited key:value".invalidNel
+              }
+
+            override def defaultMetavar: String = "key:value"
+          }
+
+          Opts
+            .options[(String, String)]("override-topics", help = "Restore a topic under a different name")(
+              colonTupleArgument
+            )
+            .map(_.toList.toMap)
+            .orNone
+
+        }
+
+        val restoreOpt = (fromWhenOpt, topicNameMapArgument).tupled.map { case (fromWhen, overrideTopics) =>
+          Restore(fromWhen, overrideTopics)
+        }
+
+        val s3Opt = Options.dataBucketOpt.mapValidated { maybeDataBucket =>
+          import io.aiven.guardian.kafka.s3.Config
+          maybeDataBucket match {
+            case Some(value) => S3(dataBucket = value).validNel
+            case _ =>
+              Options
+                .optionalPureConfigValue(() => Config.s3Config)
+                .toValidNel("S3 data bucket is a mandatory value that needs to be configured")
+          }
+        }
+
+        val initialKafkaProducerSettingsOpt
+            : Opts[Option[ProducerSettings[Array[Byte], Array[Byte]] => ProducerSettings[Array[Byte], Array[Byte]]]] =
+          Options.bootstrapServersOpt.mapValidated {
+            case Some(value) =>
+              val block =
+                (block: ProducerSettings[Array[Byte], Array[Byte]]) =>
+                  block.withBootstrapServers(value.toList.mkString(","))
+
+              Some(block).validNel
+            case None
+                if Options.checkConfigKeyIsDefined("akka.kafka.producer.kafka-clients.bootstrap.servers") || Options
+                  .checkConfigKeyIsDefined("kafka-client.bootstrap.servers") =>
+              None.validNel
+            case _ => "bootstrap-servers is a mandatory value that needs to be configured".invalidNel
+          }
+
+        val singleMessagePerRequestOpt =
+          Opts
+            .flag(
+              "single-message-per-kafka-request",
+              "A set of Kafka producer configuration options that only sends one message per request to provide exactly once message semantics without using Kafka transactions."
+            )
+            .orFalse
+
+        val kafkaProducerSettingsOpt
+            : Opts[Option[ProducerSettings[Array[Byte], Array[Byte]] => ProducerSettings[Array[Byte], Array[Byte]]]] =
+          (initialKafkaProducerSettingsOpt, singleMessagePerRequestOpt).tupled.map {
+            case (producerSettings, true) =>
+              val applySettings = (block: ProducerSettings[Array[Byte], Array[Byte]]) =>
+                block
+                  .withProperties(
+                    Map(
+                      ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG             -> true.toString,
+                      ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> 1.toString,
+                      ProducerConfig.BATCH_SIZE_CONFIG                     -> 0.toString
+                    )
+                  )
+                  .withParallelism(1)
+
+              producerSettings.map(_ andThen applySettings).orElse(Some(applySettings))
+            case (producerSettings, false) => producerSettings
+          }
+
+        (Options.storageOpt, Options.kafkaClusterOpt, kafkaProducerSettingsOpt, s3Opt, restoreOpt).mapN {
+          (storage, kafkaCluster, kafkaProducerSettings, s3, restore) =>
+            val killSwitch = KillSwitches.shared("restore-kill-switch")
+            val app = storage match {
+              case StorageOpt.S3 =>
+                new S3App {
+                  override lazy val kafkaClusterConfig: KafkaCluster          = kafkaCluster
+                  override lazy val s3Config: S3                              = s3
+                  override lazy val restoreConfig: Restore                    = restore
+                  override lazy val maybeKillSwitch: Option[SharedKillSwitch] = Some(killSwitch)
+                  override lazy val kafkaProducer =
+                    new KafkaProducer(kafkaProducerSettings)(actorSystem, restoreConfig)
+                }
+            }
+            initializedApp.set(Some(app))
+            Runtime.getRuntime.addShutdownHook(new Thread {
+              killSwitch.shutdown()
+              Await.result(app.actorSystem.terminate(), 5 minutes)
+            })
+            Await.result(app.run(), Duration.Inf)
+        }
+      }
+    )
+
+object Main extends Entry()

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreApp.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreApp.scala
@@ -1,0 +1,12 @@
+package io.aiven.guardian.kafka.restore
+
+import akka.stream.SharedKillSwitch
+import io.aiven.guardian.cli.AkkaSettings
+import io.aiven.guardian.kafka.restore.KafkaProducer
+import io.aiven.guardian.kafka.restore.{Config => RestoreConfig}
+import io.aiven.guardian.kafka.{Config => KafkaConfig}
+
+trait RestoreApp extends RestoreConfig with KafkaConfig with AkkaSettings {
+  val maybeKillSwitch: Option[SharedKillSwitch]
+  implicit lazy val kafkaProducer: KafkaProducer = new KafkaProducer()
+}

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
@@ -1,0 +1,11 @@
+package io.aiven.guardian.kafka.restore
+
+import akka.stream.alpakka.s3.S3Settings
+import io.aiven.guardian.kafka.restore.s3.RestoreClient
+import io.aiven.guardian.kafka.s3.{Config => S3Config}
+
+trait S3App extends S3Config with RestoreApp with App {
+  lazy val s3Settings: S3Settings = S3Settings()
+  implicit lazy val restoreClient: RestoreClient[KafkaProducer] =
+    new RestoreClient[KafkaProducer](Some(s3Settings), maybeKillSwitch)
+}

--- a/cli-restore/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
+++ b/cli-restore/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
@@ -1,0 +1,77 @@
+package io.aiven.guardian.kafka
+
+import io.aiven.guardian.kafka.configs.{KafkaCluster => KafkaClusterConfig}
+import io.aiven.guardian.kafka.restore.configs.{Restore => RestoreConfig}
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.propspec.AnyPropSpec
+
+import scala.annotation.nowarn
+import scala.jdk.CollectionConverters._
+
+import java.time.Instant
+import java.time.ZoneId
+
+@nowarn("msg=method main in class CommandApp is deprecated")
+class CliSpec extends AnyPropSpec with Matchers {
+
+  property("Command line args are properly passed into application") {
+    val bootstrapServer  = "localhost:9092"
+    val fromWhen         = Instant.ofEpochMilli(0).atZone(ZoneId.of("UTC")).toOffsetDateTime
+    val topic1           = "topic-1"
+    val topic2           = "topic-2"
+    val restoreTopicOne  = s"restore-$topic1"
+    val restoreTopicTwo  = s"restore-$topic2"
+    val overrideTopicOne = s"$topic1:$restoreTopicOne"
+    val overrideTopicTwo = s"$topic2:$restoreTopicTwo"
+    val dataBucket       = "backup-bucket"
+
+    val args = List(
+      "--storage",
+      "s3",
+      "--kafka-topics",
+      topic1,
+      "--kafka-topics",
+      topic2,
+      "--kafka-bootstrap-servers",
+      bootstrapServer,
+      "--s3-data-bucket",
+      dataBucket,
+      "--from-when",
+      fromWhen.toString,
+      "--override-topics",
+      overrideTopicOne,
+      "--override-topics",
+      overrideTopicTwo,
+      "--single-message-per-kafka-request"
+    )
+
+    try restore.Main.main(args.toArray)
+    catch {
+      case _: Throwable =>
+    }
+    restore.Main.initializedApp.get() match {
+      case Some(s3App: restore.S3App) =>
+        s3App.restoreConfig mustEqual RestoreConfig(Some(fromWhen),
+                                                    Some(
+                                                      Map(
+                                                        topic1 -> restoreTopicOne,
+                                                        topic2 -> restoreTopicTwo
+                                                      )
+                                                    )
+        )
+        s3App.kafkaClusterConfig mustEqual KafkaClusterConfig(Set(topic1, topic2))
+        s3App.kafkaProducer.producerSettings.getProperties.get("bootstrap.servers") mustEqual bootstrapServer
+        s3App.s3Config.dataBucket mustEqual dataBucket
+        (Map(
+          ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG             -> true.toString,
+          ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> 1.toString,
+          ProducerConfig.BATCH_SIZE_CONFIG                     -> 0.toString
+        ): Map[String, AnyRef]).toSet
+          .subsetOf(s3App.kafkaProducer.producerSettings.getProperties.asScala.toMap.toSet) mustEqual true
+        s3App.kafkaProducer.producerSettings.parallelism mustEqual 1
+      case _ =>
+        fail("Expected an App to be initialized")
+    }
+  }
+}

--- a/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/MockedRestoreClientInterface.scala
+++ b/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/MockedRestoreClientInterface.scala
@@ -2,6 +2,7 @@ package io.aiven.guardian.kafka.restore
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.aiven.guardian.kafka.configs.KafkaCluster
@@ -15,6 +16,8 @@ class MockedRestoreClientInterface(backupData: Map[String, ByteString])(implicit
     override val kafkaClusterConfig: KafkaCluster,
     override val system: ActorSystem
 ) extends RestoreClientInterface[MockedKafkaProducerInterface] {
+
+  override val maybeKillSwitch: Option[SharedKillSwitch] = None
 
   override def retrieveBackupKeys: Future[List[String]] = Future.successful(
     backupData.keys.toList

--- a/restore-s3/src/main/scala/io/aiven/guardian/kafka/restore/s3/RestoreClient.scala
+++ b/restore-s3/src/main/scala/io/aiven/guardian/kafka/restore/s3/RestoreClient.scala
@@ -2,6 +2,7 @@ package io.aiven.guardian.kafka.restore.s3
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.SharedKillSwitch
 import akka.stream.alpakka.s3.S3Attributes
 import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
@@ -18,7 +19,9 @@ import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class RestoreClient[T <: KafkaProducerInterface](maybeS3Settings: Option[S3Settings])(implicit
+class RestoreClient[T <: KafkaProducerInterface](maybeS3Settings: Option[S3Settings],
+                                                 override val maybeKillSwitch: Option[SharedKillSwitch]
+)(implicit
     override val kafkaProducerInterface: T,
     override val restoreConfig: Restore,
     override val kafkaClusterConfig: KafkaCluster,

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
@@ -94,7 +94,7 @@ class RealS3RestoreClientSpec
           )
 
         val restoreClient =
-          new RestoreClient[KafkaProducer](Some(s3Settings))
+          new RestoreClient[KafkaProducer](Some(s3Settings), None)
 
         val adminClient = AdminClient.create(
           Map[String, AnyRef](


### PR DESCRIPTION
# About this change - What it does

This PR implements CLI for the restore portion of guardian.

# Why this way

The structure of the PR is pretty much the same as the earlier one that implemented CLI for backup (see https://github.com/aiven/guardian-for-apache-kafka/pull/83) with some additional notes/exceptions

* A
  ```scala
  try backup.Main.main(args.toArray)
  catch {
    case _: Throwable =>
  }
  ```
  was added to the `CliSpec` tests for restore and the already existing backup. This is necessary because the `Main` part of 
  `Restore` will throw an exception when initialized because not all of the data passed into main test actually exists (i.e. 
  `backup-bucket` doesn't actually exist in S3). Note that the purpose of these tests is to see if the command line arguments are 
  being correctly passed into the application's configuration, its **NOT** testing that the application actually runs correctly with 
  those arguments (thats for proper end2end tests which exist elsewhere)
    * Technically speaking the `try/catch` clause is not necessary for the backup because it happens to gracefully shutdown without an exception however this is an internal detail and so I added the `try/catch` clause to backup for consistency reasons
* If for whatever reason the configuration isn't initialized in the tests we fail with `Expected an App to be initialized`. This change was done both for new Restore and current Backup. Without this change the tests wouldn't actually fail in this case as expected.
* The `override-topics` argument consists of a list of colon (`:`) delimited key/values. This is because there is no standard way to parse map/dict like structures as command line arguments.
  * `:` Was picked because its not a valid character that can be used in kafka topics (see https://www.ibm.com/docs/en/integration-bus/10.0?topic=bus-producing-messages-kafka-topics). As a bonus it aesthetically looks nice.
* In addition to the typical command line configuration parameters `single-message-per-kafka-request` has been added. This cli flag configures the Kafka producer with a set of configuration's whos semantics allow exactly once message delivery semantics without having to use Kafka transaction API (see https://github.com/aiven/guardian-for-apache-kafka/issues/98). 
  * It is intended that the underlying configurations of `single-message-per-kafka-request` can possibly change but the user can just rely on the fact that `single-message-per-kafka-request` provides these semantics
  * When Kafka transactional API is supported this will be under a different CLI flag (since to use the transactional API properly you also need to setup the consumer in a specific way which is outside the control of the restore app, the restore app only contains a publisher and not a consumer).
  * I am open to using a different name than `single-message-per-kafka-request` as long as it doesn't contain `transactional` so its not confused with the official Kafka transactional API.
* `RestoreClientInterface`/`RestoreClient` was adjusted to accommodate a `KillSwitch`. Unlike `Backup` which gives a `Control` (that is gotten from the Alpakka Kafka consumer), the `Alpakka` producer has no such mechanism so we use a standard akka-stream killswitch which will gracefully terminate the entire stream.
* The cli `Main` waits forever when calling `restore.run()` with `Await.result(app.run(), Duration.Inf)`. I did it initially this way because restore's can take significant amounts of time (theoretically even days?) and so I didn't want to add an upper bound on how long it takes because in doing so you kind of defeat the point of having an upper bound anyways.