### PR TITLE
Fix flaky test

### DIFF
--- a/core-s3/src/test/scala/akka/stream/alpakka/s3/GeneratorsSpec.scala
+++ b/core-s3/src/test/scala/akka/stream/alpakka/s3/GeneratorsSpec.scala
@@ -21,7 +21,7 @@ class GeneratorsSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyCh
   }
 
   def withPrefixGen(useVirtualDotHost: Boolean): Gen[String] = for {
-    range      <- Gen.choose(2, Generators.MaxBucketLength - 2)
+    range      <- Gen.choose(2, Generators.MaxBucketLength - 3)
     firstChar  <- Generators.bucketLetterOrNumberCharGen
     chars      <- Gen.listOfN(range, Generators.bucketAllCharGen(useVirtualDotHost = false))
     bucketName <- Generators.bucketNameGen(useVirtualDotHost, Some((firstChar +: chars).mkString))


### PR DESCRIPTION
# About this change - What it does
The flaky tests were due to this fancepost error. I ran the tests on loop to make sure that it fixed the flakiness

Resolves: #114 

# Why this way

This just happened to be one character less than the legal amount for an s3 prefix.
