### PR TITLE
Skip integration tests from running if secrets not available

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -30,7 +30,7 @@ trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll with 
   val ThrottleElements: Int          = 100
   val ThrottleAmount: FiniteDuration = 1 millis
 
-  property("backup method completes flow correctly for all valid Kafka events") {
+  property("backup method completes flow correctly for all valid Kafka events", RealS3Available) {
     forAll(kafkaDataWithTimePeriodsGen(), s3ConfigGen(useVirtualDotHost, bucketPrefix)) {
       (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
         logger.info(s"Data bucket is ${s3Config.dataBucket}")

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -84,7 +84,7 @@ class RealS3BackupClientSpec
     else
       akka.pattern.after(step)(waitUntilBackupClientHasCommitted(backupClient, step, delay))
 
-  property("basic flow without interruptions using PeriodFromFirst works correctly") {
+  property("basic flow without interruptions using PeriodFromFirst works correctly", RealS3Available) {
     forAll(kafkaDataWithMinSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) { (kafkaDataInChunksWithTimePeriod: KafkaDataInChunksWithTimePeriod, s3Config: S3Config) =>
@@ -168,7 +168,7 @@ class RealS3BackupClientSpec
     }
   }
 
-  property("suspend/resume using PeriodFromFirst creates separate object after resume point") {
+  property("suspend/resume using PeriodFromFirst creates separate object after resume point", RealS3Available) {
     forAll(kafkaDataWithMinSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) { (kafkaDataInChunksWithTimePeriod: KafkaDataInChunksWithTimePeriod, s3Config: S3Config) =>
@@ -303,7 +303,7 @@ class RealS3BackupClientSpec
     }
   }
 
-  property("suspend/resume for same object using ChronoUnitSlice works correctly") {
+  property("suspend/resume for same object using ChronoUnitSlice works correctly", RealS3Available) {
     forAll(kafkaDataWithMinSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) { (kafkaDataInChunksWithTimePeriod: KafkaDataInChunksWithTimePeriod, s3Config: S3Config) =>

--- a/core-s3/src/test/scala/akka/stream/alpakka/s3/GeneratorsSpec.scala
+++ b/core-s3/src/test/scala/akka/stream/alpakka/s3/GeneratorsSpec.scala
@@ -1,22 +1,64 @@
 package akka.stream.alpakka.s3
 
-import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import io.aiven.guardian.kafka.s3.Generators
 import org.scalacheck.Gen
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+import scala.annotation.nowarn
+
 class GeneratorsSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyChecks {
+
+  def createBasicConfigFactory(virtualDotHost: Boolean): Config = {
+    @nowarn("msg=possible missing interpolator: detected an interpolated expression")
+    val baseS3SettingsConf =
+      """
+        |buffer = "memory"
+        |disk-buffer-path = ""
+        |
+        |aws {
+        |  credentials {
+        |    provider = default
+        |  }
+        |  region {
+        |    provider = default
+        |  }
+        |}
+        |access-style = virtual
+        |list-bucket-api-version = 2
+        |validate-object-key = true
+        |retry-settings {
+        |  max-retries = 3
+        |  min-backoff = 200ms
+        |  max-backoff = 10s
+        |  random-factor = 0.0
+        |}
+        |multipart-upload {
+        |  retry-settings = ${retry-settings}
+        |}
+        |sign-anonymous-requests = true
+        |""".stripMargin
+
+    val config = ConfigFactory.parseString(baseS3SettingsConf).resolve()
+    if (virtualDotHost)
+      config.withValue("access-style", ConfigValueFactory.fromAnyRef("virtual"))
+    else
+      config.withValue("access-style", ConfigValueFactory.fromAnyRef("path"))
+  }
+
   property("Bucket name generators generates valid bucket names according to S3Settings with virtualDotHost") {
     forAll(Generators.bucketNameGen(useVirtualDotHost = true)) { bucket =>
-      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(ActorSystem()))
+      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(createBasicConfigFactory(true)))
     }
   }
 
   property("Bucket name generators generates valid bucket names according to S3Settings without virtualDotHost") {
     forAll(Generators.bucketNameGen(useVirtualDotHost = false)) { bucket =>
-      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(ActorSystem()))
+      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(createBasicConfigFactory(false)))
     }
   }
 
@@ -31,7 +73,7 @@ class GeneratorsSpec extends AnyPropSpec with Matchers with ScalaCheckPropertyCh
     "Bucket name generators generates valid bucket names according to S3Settings with virtualDotHost and prefix"
   ) {
     forAll(withPrefixGen(useVirtualDotHost = true)) { bucket =>
-      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(ActorSystem()))
+      noException must be thrownBy BucketAndKey.validateBucketName(bucket, S3Settings(createBasicConfigFactory(true)))
     }
   }
 }

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -13,8 +13,11 @@ import akka.stream.scaladsl.Source
 import akka.testkit.TestKitBase
 import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.akka.AkkaHttpTestKit
+import io.aiven.guardian.kafka.TestUtils
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.Ignore
+import org.scalatest.Tag
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.propspec.AnyPropSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -37,6 +40,12 @@ trait S3Spec
     with ScalaFutures
     with Config
     with StrictLogging {
+
+  // See https://stackoverflow.com/a/38834773
+  case object RealS3Available
+      extends Tag(
+        if (TestUtils.checkEnvVarAvailable("ALPAKKA_S3_REGION_DEFAULT_REGION")) "" else classOf[Ignore].getName
+      )
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(5 minutes, 100 millis)

--- a/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
@@ -81,4 +81,11 @@ object TestUtils {
     recurseUntilHitTimeUnit(previousEnum, buffer)
   }
 
+  def checkEnvVarAvailable(env: String): Boolean =
+    try
+      sys.env.contains(env)
+    catch {
+      case _: NoSuchElementException => false
+    }
+
 }

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
@@ -64,7 +64,7 @@ class RealS3RestoreClientSpec
   override lazy val bucketPrefix: Option[String]          = Some("guardian-")
   override lazy val enableCleanup: Option[FiniteDuration] = Some(5 seconds)
 
-  property("Round-trip with backup and restore") {
+  property("Round-trip with backup and restore", RealS3Available) {
     forAll(kafkaDataWithMinSizeRenamedTopicsGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) {


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This PR skips tests from running if those tests rely on secrets for actual real services
Resolves: #118

# Why this way

The first part of the PR involves adding a ScalaTest tag that will ignore the test if a mandatory S3 secret is not resolvable (`ALPAKKA_S3_REGION_DEFAULT_REGION`). The tag's are nice abstraction since you can apply them optionally and easily to existing tests.

The second part of the PR needs some context explanation. The primary goal of this PR is solving #118 where S3 secrets are not resolved in CI tests by PR's that are created from forks. Annoyingly when secrets are not resolved this way, rather than unset'ting the environment variable you just get an empty environment variable and/or some of the env vars are missing since the others are statically defined (i.e. https://github.com/aiven/guardian-for-apache-kafka/blob/main/.github/workflows/ci.yml#L20). This causes a `NullPointerThrown` exception in `GeneratorsSpec` because the configuration is malformed.

The most sane way I found for getting around this is to just prevent the spec from reading from the environment/reference.conf and rather hardcode the configuration from the string.