### PR TITLE
Fix environment variable for detecting missing secret

### DIFF
--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -44,7 +44,7 @@ trait S3Spec
   // See https://stackoverflow.com/a/38834773
   case object RealS3Available
       extends Tag(
-        if (TestUtils.checkEnvVarAvailable("ALPAKKA_S3_REGION_DEFAULT_REGION")) "" else classOf[Ignore].getName
+        if (TestUtils.checkEnvVarAvailable("ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID")) "" else classOf[Ignore].getName
       )
 
   implicit val ec: ExecutionContext            = system.dispatcher


### PR DESCRIPTION
# About this change - What it does

In the PR https://github.com/aiven/guardian-for-apache-kafka/pull/119 I accidentally used the wrong environment variable. `ALPAKKA_S3_REGION_DEFAULT_REGION` is statically set in https://github.com/aiven/guardian-for-apache-kafka/blob/main/.github/workflows/ci.yml#L18 so it will always be true, instead `ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID` should be used

