### PR TITLE
Check if evaluated environment variable is empty string

### DIFF
--- a/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
@@ -84,8 +84,8 @@ object TestUtils {
   def checkEnvVarAvailable(env: String): Boolean =
     try
       sys.env.get(env) match {
-        case Some(_)                      => true
         case Some(value) if value.isBlank => false
+        case Some(_)                      => true
         case None                         => false
       }
     catch {

--- a/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
@@ -83,7 +83,11 @@ object TestUtils {
 
   def checkEnvVarAvailable(env: String): Boolean =
     try
-      sys.env.contains(env)
+      sys.env.get(env) match {
+        case Some(_)                      => true
+        case Some(value) if value.isBlank => false
+        case None                         => false
+      }
     catch {
       case _: NoSuchElementException => false
     }


### PR DESCRIPTION
# About this change - What it does

When checking for environment variables existing we also need to check that the environment variable doesn't evaluate to an empty string

The error that we are getting for forked PR's is so empty strings is what its actually being evaluated to.

```
[info] - backup method completes flow correctly for all valid Kafka events *** FAILED ***
[info]   NullPointerException was thrown during property evaluation.
[info]     Message: Access key ID cannot be blank.
```