### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,20 +12,21 @@ val akkaHttpVersion            = "10.2.8"
 val alpakkaKafkaVersion        = "3.0.0"
 val alpakkaVersion             = "3.0.4"
 val quillJdbcMonixVersion      = "3.7.2"
-val postgresqlJdbcVersion      = "42.2.25"
+val postgresqlJdbcVersion      = "42.3.3"
 val scalaLoggingVersion        = "3.9.4"
 val logbackClassicVersion      = "1.2.10"
 val declineVersion             = "2.2.0"
 val pureConfigVersion          = "0.17.1"
-val scalaTestVersion           = "3.2.9"
-val scalaTestScalaCheckVersion = "3.2.9.0"
+val scalaTestVersion           = "3.2.11"
+val scalaTestScalaCheckVersion = "3.2.11.0"
 val akkaStreamsJson            = "0.8.0"
 val diffxVersion               = "0.7.0"
-val testContainersVersion      = "0.40.0"
-val testContainersJavaVersion  = "1.16.2"
+val testContainersVersion      = "0.40.2"
+val testContainersJavaVersion  = "1.16.3"
 val scalaCheckVersion          = "1.15.5-1-SNAPSHOT"
 val scalaCheckOpsVersion       = "2.8.1"
 val enumeratumVersion          = "1.7.0"
+val organizeImportsVersion     = "0.6.0"
 
 val flagsFor12 = Seq(
   "-Xlint:_",
@@ -270,7 +271,7 @@ ThisBuild / githubWorkflowBuildPreamble := Seq(
 )
 
 // Configuration needed for Scalafix
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0"
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % organizeImportsVersion
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta"         % "sbt-scalafmt"        % "2.4.6")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox"         % "0.9.2")
-addSbtPlugin("com.github.sbt"        % "sbt-native-packager" % "1.9.8")
+addSbtPlugin("com.github.sbt"        % "sbt-native-packager" % "1.9.9")
 addSbtPlugin("com.codecommit"        % "sbt-github-actions"  % "0.14.2")
 addSbtPlugin("com.github.sbt"        % "sbt-pgp"             % "2.1.2")
 addSbtPlugin("com.github.sbt"        % "sbt-release"         % "1.1.0")


### PR DESCRIPTION
# About this change - What it does

Updates dependencies
Resolves: #xxxxx

# Why this way

This should be the last time we have to manually update PR's. I had to close the previous scala-steward PR's but now that I confirmed that forked PR's can execute CI tests fine future scala-steward PR's should work without issues.
