### PR TITLE
Increase timeout to 10 minutes

### DIFF
--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -48,7 +48,7 @@ trait S3Spec
       )
 
   implicit val ec: ExecutionContext            = system.dispatcher
-  implicit val defaultPatience: PatienceConfig = PatienceConfig(5 minutes, 100 millis)
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(10 minutes, 100 millis)
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1, minSize = 1)
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Increases the timeout for S3 related tests to 10 minutes

# Why this way

5 minutes can be too short, caused https://github.com/aiven/guardian-for-apache-kafka/runs/5383900785?check_suite_focus=true to fail
