### PR TITLE
Update sbt-coveralls to 1.3.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,15 +6,5 @@ addSbtPlugin("com.github.sbt"        % "sbt-pgp"              % "2.1.2")
 addSbtPlugin("com.github.sbt"        % "sbt-release"          % "1.1.0")
 addSbtPlugin("ch.epfl.scala"         % "sbt-scalafix"         % "0.9.34")
 addSbtPlugin("org.scoverage"         % "sbt-scoverage"        % "1.9.3")
-addSbtPlugin("org.scoverage"         % "sbt-coveralls"        % "1.3.1")
+addSbtPlugin("org.scoverage"         % "sbt-coveralls"        % "1.3.2")
 addSbtPlugin("net.vonbuchholtz"      % "sbt-dependency-check" % "3.4.1")
-
-// This is here due to https://github.com/scoverage/sbt-coveralls/issues/179. When
-// sbt-coveralls releases a new version higher than 1.3.1 you can remove this
-val jacksonDowngradeVersion = "2.12.5"
-dependencyOverrides ++= Seq(
-  "com.fasterxml.jackson.core"    % "jackson-core"         % jacksonDowngradeVersion,
-  "com.fasterxml.jackson.core"    % "jackson-databind"     % jacksonDowngradeVersion,
-  "com.fasterxml.jackson.core"    % "jackson-annotations"  % jacksonDowngradeVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonDowngradeVersion
-)


### PR DESCRIPTION
# About this change - What it does

Updates to sbt-coveralls 1.3.2 as well as removing the old workaround
