### PR TITLE
Fix core-cli missing from classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,13 @@ lazy val core = project
 lazy val coreCli = project
   .in(file("core-cli"))
   .settings(
-    cliSettings,
+    publish / skip       := true,
+    publishLocal / skip  := true,
+    publishSigned / skip := true,
+    scalacOptions ++= Seq(
+      "-opt-inline-from:**", // See https://www.lightbend.com/blog/scala-inliner-optimizer
+      "-opt:l:method"
+    ) ++ flagsFor13,
     name := s"$baseName-core-cli",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor"  % akkaVersion,


### PR DESCRIPTION
# About this change - What it does

Makes sure that `core-cli` is available in the classpath when creating a package for the cli projects

# Why this way

`publishArtifact := false` which was defined in `cliSettings` was causing the sbt-native-package to completely skip the `*-core-cli.jar` in the classpath which caused the app to fail to run with

```
backup-0.1.0-SNAPSHOT ./bin/guardian-for-apache-kafka-cli-backup 
Exception in thread "main" java.lang.NoClassDefFoundError: io/aiven/guardian/cli/options/Options$
	at io.aiven.guardian.kafka.backup.Entry.<init>(Main.scala:56)
	at io.aiven.guardian.kafka.backup.Main$.<init>(Main.scala:104)
	at io.aiven.guardian.kafka.backup.Main$.<clinit>(Main.scala:104)
	at io.aiven.guardian.kafka.backup.Main.main(Main.scala)
Caused by: java.lang.ClassNotFoundException: io.aiven.guardian.cli.options.Options$
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 4 more
```

Since `core-cli` is common and only used once I just extracted the necessary options