### PR TITLE
Fix github-actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/aiven/guardian-for-apache-kafka/actions/workflows/ci.yml/badge.svg)](https://github.com/aiven/guardian-for-apache-kafka/actions)
+[![Build Status](https://github.com/aiven/guardian-for-apache-kafka/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/aiven/guardian-for-apache-kafka/actions/workflows/ci.yml?query=branch%3Amain)
 [![Apache License](https://img.shields.io/badge/license-APACHE_2-green.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Coverage](https://coveralls.io/repos/github/aiven/guardian-for-apache-kafka/badge.svg?branch=main)](https://coveralls.io/github/aiven/guardian-for-apache-kafka?branch=main)
 


### PR DESCRIPTION
# About this change - What it does

This PR fixes the github-actions badge so that it refers to the `main` branch.

# Why this way

The previous version was checking that ALL github actions was passed/failed where as in reality we only want to check that the main branch is passing (otherwise someone can make a PR with a failing CI that will reflect in the badge).
