### PR TITLE
Add ssh-key to publish docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,4 +127,8 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.GH_PAGES_SSH_PRIVATE_KEY }}
+
       - run: sbt ++${{ matrix.scala }} docs/ghpagesPushSite

--- a/build.sbt
+++ b/build.sbt
@@ -355,6 +355,14 @@ ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.Equals(Ref.Branch("main")))
 
 ThisBuild / githubWorkflowPublish := Seq(WorkflowStep.Sbt(List("docs/ghpagesPushSite")))
+ThisBuild / githubWorkflowPublishPreamble := Seq(
+  WorkflowStep.Use(
+    ref = UseRef.Public("webfactory", "ssh-agent", "v0.5.4"),
+    params = Map(
+      "ssh-private-key" -> "${{ secrets.GH_PAGES_SSH_PRIVATE_KEY }}"
+    )
+  )
+)
 
 ThisBuild / githubWorkflowBuildPreamble := Seq(
   WorkflowStep.Sbt(List("scalafixAll --check"), name = Some("Linter: Scalafix checks"))


### PR DESCRIPTION
# About this change - What it does

This PR fixes docs publishing for Guardian by using a SSH key that has permissions to push to a different github branch

# Why this way

See https://github.com/webfactory/ssh-agent#usage for implementation details.
