### PR TITLE
Set git user and email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_SSH_PRIVATE_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -356,6 +356,13 @@ ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.Equals(Ref.B
 
 ThisBuild / githubWorkflowPublish := Seq(WorkflowStep.Sbt(List("docs/ghpagesPushSite")))
 ThisBuild / githubWorkflowPublishPreamble := Seq(
+  // Taken from https://github.com/actions/checkout/issues/13#issue-481453396
+  WorkflowStep.Run(
+    commands = List(
+      "git config --global user.name \"$(git --no-pager log --format=format:'%an' -n 1)\"",
+      "git config --global user.email \"$(git --no-pager log --format=format:'%ae' -n 1)\""
+    )
+  ),
   WorkflowStep.Use(
     ref = UseRef.Public("webfactory", "ssh-agent", "v0.5.4"),
     params = Map(


### PR DESCRIPTION
# About this change - What it does

Sets the git user and email for the github pages publish step.

# Why this way

Since there is no checkout for the publish step the git user/email is not being set, this change rectifies that problem.
