### PR TITLE
Update latest parboiled

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,0 @@
--XX:+IgnoreUnrecognizedVMOptions
---add-opens java.base/java.lang=ALL-UNNAMED
---illegal-access=permit

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,8 +16,9 @@ addSbtPlugin("org.scoverage"                     % "sbt-coveralls"            % 
 addSbtPlugin("net.vonbuchholtz"                  % "sbt-dependency-check"     % "4.0.0")
 
 // This is here to bump dependencies for sbt-paradox/sbt-site, see
-// https://github.com/sirthias/parboiled/issues/175 and https://github.com/sirthias/parboiled/issues/128
+// https://github.com/sirthias/parboiled/issues/175, https://github.com/sirthias/parboiled/issues/128 and
+// https://github.com/sirthias/parboiled/pull/195
 libraryDependencies ++= Seq(
-  "org.parboiled" %% "parboiled-scala" % "1.4.0",
-  "org.parboiled"  % "parboiled-java"  % "1.4.0"
+  "org.parboiled" %% "parboiled-scala" % "1.4.1",
+  "org.parboiled"  % "parboiled-java"  % "1.4.1"
 )


### PR DESCRIPTION
# About this change - What it does

Updates to latest parboiled  which fixes the issues of needing specific JVM parameters due to changes to JDK's `unsafe`

# Why this way

I just checked on my system whether the latest version works with JDK11/JDK17 and it works without needing the `.jvmpopts`
