### PR TITLE
Configure scala-steward to always update PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updatePullRequests = "always"


### PR DESCRIPTION
# About this change - What it does

This change configures scala-steward to always update the PR's it creates

# Why this way

Due to our configuration of our branch merging strategy, whenever the base branch is out of date scala-steward doesn't update the PR's (example is https://github.com/aiven/guardian-for-apache-kafka/pull/140). This PR fixes the issue.
