### PR TITLE
Fix kafka-clients configs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ ThisBuild / resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/c
 val akkaVersion                = "2.6.18"
 val akkaHttpVersion            = "10.2.9"
 val alpakkaKafkaVersion        = "3.0.0"
+val kafkaClientsVersion        = "3.0.0"
 val alpakkaVersion             = "3.0.4"
 val quillJdbcMonixVersion      = "3.7.2"
 val postgresqlJdbcVersion      = "42.3.3"
@@ -109,9 +110,13 @@ lazy val core = project
     librarySettings,
     name := s"$baseName-core",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka"          %% "akka-actor"                     % akkaVersion                % Provided,
-      "com.typesafe.akka"          %% "akka-stream"                    % akkaVersion                % Provided,
-      "com.typesafe.akka"          %% "akka-stream-kafka"              % alpakkaKafkaVersion,
+      "com.typesafe.akka" %% "akka-actor"        % akkaVersion % Provided,
+      "com.typesafe.akka" %% "akka-stream"       % akkaVersion % Provided,
+      "com.typesafe.akka" %% "akka-stream-kafka" % alpakkaKafkaVersion,
+      // Ideally we shouldn't be explicitly providing a kafka-clients version and instead getting the version
+      // transitively from akka-streams-kafka however there isn't a nice way to extract a transitive dependency
+      // for usage in linking to documentation.
+      "org.apache.kafka"            % "kafka-clients"                  % kafkaClientsVersion,
       "com.typesafe.scala-logging" %% "scala-logging"                  % scalaLoggingVersion,
       "com.github.pureconfig"      %% "pureconfig"                     % pureConfigVersion,
       "ch.qos.logback"              % "logback-classic"                % logbackClassicVersion,
@@ -312,16 +317,18 @@ lazy val docs = project
     git.remoteRepo               := scmInfo.value.get.connection.replace("scm:git:", ""),
     paradoxGroups                := Map("Language" -> Seq("Scala")),
     paradoxProperties ++= Map(
-      "akka.version"                        -> akkaVersion,
-      "akka-http.version"                   -> akkaHttpVersion,
-      "akka-streams-json.version"           -> akkaStreamsJson,
-      "pure-config.version"                 -> pureConfigVersion,
-      "decline.version"                     -> declineVersion,
-      "scala-logging.version"               -> scalaLoggingVersion,
-      "extref.akka.base_url"                -> s"https://doc.akka.io/docs/akka/${binaryVersion(akkaVersion)}/%s",
-      "extref.akka-stream-json.base_url"    -> s"https://github.com/mdedetrich/akka-streams-json",
-      "extref.alpakka.base_url"             -> s"https://doc.akka.io/api/alpakka/${binaryVersion(alpakkaVersion)}/%s",
-      "extref.alpakka-docs.base_url"        -> s"https://docs.akka.io/docs/alpakka/${binaryVersion(alpakkaVersion)}/%s",
+      "akka.version"                     -> akkaVersion,
+      "akka-http.version"                -> akkaHttpVersion,
+      "akka-streams-json.version"        -> akkaStreamsJson,
+      "pure-config.version"              -> pureConfigVersion,
+      "decline.version"                  -> declineVersion,
+      "scala-logging.version"            -> scalaLoggingVersion,
+      "extref.akka.base_url"             -> s"https://doc.akka.io/docs/akka/${binaryVersion(akkaVersion)}/%s",
+      "extref.akka-stream-json.base_url" -> s"https://github.com/mdedetrich/akka-streams-json",
+      "extref.alpakka.base_url"          -> s"https://doc.akka.io/api/alpakka/${binaryVersion(alpakkaVersion)}/%s",
+      "extref.alpakka-docs.base_url"     -> s"https://docs.akka.io/docs/alpakka/${binaryVersion(alpakkaVersion)}/%s",
+      "extref.alpakka-kafka-docs.base_url" -> s"https://docs.akka.io/docs/alpakka-kafka/${binaryVersion(alpakkaVersion)}/%s",
+      "extref.kafka-docs.base_url" -> s"https://kafka.apache.org/${binaryVersion(kafkaClientsVersion).replace(".", "")}/%s",
       "extref.pureconfig.base_url"          -> s"https://pureconfig.github.io/docs/",
       "scaladoc.io.aiven.guardian.base_url" -> s"/guardian-for-apache-kafka/${(Preprocess / siteSubdirName).value}/"
     )

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -73,9 +73,7 @@ class Entry(val initializedApp: AtomicReference[Option[App[_]]] = new AtomicRefe
                   block.withBootstrapServers(value.toList.mkString(","))
 
               Some(block).validNel
-            case None
-                if Options.checkConfigKeyIsDefined("akka.kafka.consumer.kafka-clients.bootstrap.servers") || Options
-                  .checkConfigKeyIsDefined("kafka-client.bootstrap.servers") =>
+            case None if Options.checkConfigKeyIsDefined("akka.kafka.consumer.kafka-clients.bootstrap.servers") =>
               None.validNel
             case _ => "bootstrap-servers is a mandatory value that needs to be configured".invalidNel
           }

--- a/core-backup/src/main/resources/reference.conf
+++ b/core-backup/src/main/resources/reference.conf
@@ -1,3 +1,43 @@
+akka.kafka.consumer = {
+    poll-interval = ${?AKKA_KAFKA_CONSUMER_POLL_INTERVAL}
+    poll-timeout = ${?AKKA_KAFKA_CONSUMER_POLL_TIMEOUT}
+    stop-timeout = ${?AKKA_KAFKA_CONSUMER_STOP_TIMEOUT}
+    close-timeout = ${?AKKA_KAFKA_CONSUMER_CLOSE_TIMEOUT}
+    commit-timeout = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIMEOUT}
+    commit-time-warning = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIME_WARNING}
+    commit-refresh-interval = ${?AKKA_KAFKA_CONSUMER_COMMIT_REFRESH_INTERVAL}
+    use-dispatcher = ${?AKKA_KAFKA_CONSUMER_USE_DISPATCHER}
+    wait-close-partition = ${?AKKA_KAFKA_CONSUMER_WAIT_CLOSE_PARTITION}
+    position-timeout = ${?AKKA_KAFKA_CONSUMER_POSITION_TIMEOUT}
+    offset-for-times-timeout = ${?AKKA_KAFKA_OFFSET_FOR_TIMES_TIMEOUT}
+    metadata-request-timeout = ${?AKKA_KAFKA_METADATA_REQUEST_TIMEOUT}
+    eos-draining-check-interval = ${?AKKA_KAFKA_CONSUMER_EOS_DRAINING_CHECK_INTERVAL}
+    connection-checker = {
+        enable = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_ENABLE}
+        max-retries = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_MAX_RETRIES}
+        backoff-factor = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_BACKOFF_FACTOR}
+        check-interval = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_CHECK_INTERVAL}
+    }
+    partition-handler-warning = ${?AKKA_KAFKA_CONSUMER_PARTITION_HANDLER_WARNING}
+    offset-reset-protection = {
+        enable = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_ENABLE}
+        offset-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_OFFSET_THRESHOLD}
+        time-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_TIME_THRESHOLD}
+    }
+
+    # Configurations for org.apache.kafka.clients.consumer.ConsumerConfig
+    kafka-clients = ${?AKKA_KAFKA_CONSUMER_KAFKA_CLIENTS}
+}
+
+akka.kafka.committer = {
+    max-batch = 100000
+    max-batch = ${?AKKA_KAFKA_COMMITTER_MAX_BATCH}
+    max-interval = 1 hour
+    max-interval = ${?AKKA_KAFKA_COMMITTER_MAX_INTERVAL}
+    parallelism = ${?AKKA_KAFKA_COMMITTER_PARALLELISM}
+    parallelism = 10000
+}
+
 backup {
     kafka-group-id = ${?BACKUP_KAFKA_GROUP_ID}
     time-configuration = {

--- a/core-restore/src/main/resources/reference.conf
+++ b/core-restore/src/main/resources/reference.conf
@@ -1,3 +1,17 @@
+akka.kafka.producer {
+    discovery-method = ${?AKKA_KAFKA_PRODUCER_DISCOVERY_METHOD}
+    service-name = ${?AKKA_KAFKA_PRODUCER_SERVICE_NAME}
+    resolve-timeout = ${?AKKA_KAFKA_PRODUCER_RESOLVE_TIMEOUT}
+    parallelism = ${?AKKA_KAFKA_PRODUCER_PARALLELISM}
+    close-timeout = ${?AKKA_KAFKA_PRODUCER_CLOSE_TIMEOUT}
+    close-on-producer-stop = ${?AKKA_KAFKA_PRODUCER_CLOSE_ON_PRODUCER_STOP}
+    use-dispatcher = ${?AKKA_KAFKA_PRODUCER_USE_DISPATCHER}
+    eos-commit-interval = ${?AKKA_KAFKA_PRODUCER_EOS_COMMIT_INTERVAL}
+
+    # Configurations for org.apache.kafka.clients.producer.ProducerConfig
+    kafka-clients = ${?AKKA_KAFKA_PRODUCER_KAFKA_CLIENTS}
+}
+
 restore {
     from-when = ${?RESTORE_FROM_WHEN}
     override-topics = ${?RESTORE_OVERRIDE_TOPICS}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -3,59 +3,6 @@
 akka.http.client.stream-cancellation-delay = 1000 millis
 akka.http.client.stream-cancellation-delay = ${?AKKA_HTTP_CLIENT_STREAM_CANCELLATION_DELAY}
 
-akka.kafka.consumer = {
-    poll-interval = ${?AKKA_KAFKA_CONSUMER_POLL_INTERVAL}
-    poll-timeout = ${?AKKA_KAFKA_CONSUMER_POLL_TIMEOUT}
-    stop-timeout = ${?AKKA_KAFKA_CONSUMER_STOP_TIMEOUT}
-    close-timeout = ${?AKKA_KAFKA_CONSUMER_CLOSE_TIMEOUT}
-    commit-timeout = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIMEOUT}
-    commit-time-warning = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIME_WARNING}
-    commit-refresh-interval = ${?AKKA_KAFKA_CONSUMER_COMMIT_REFRESH_INTERVAL}
-    use-dispatcher = ${?AKKA_KAFKA_CONSUMER_USE_DISPATCHER}
-    wait-close-partition = ${?AKKA_KAFKA_CONSUMER_WAIT_CLOSE_PARTITION}
-    position-timeout = ${?AKKA_KAFKA_CONSUMER_POSITION_TIMEOUT}
-    offset-for-times-timeout = ${?AKKA_KAFKA_OFFSET_FOR_TIMES_TIMEOUT}
-    metadata-request-timeout = ${?AKKA_KAFKA_METADATA_REQUEST_TIMEOUT}
-    eos-draining-check-interval = ${?AKKA_KAFKA_CONSUMER_EOS_DRAINING_CHECK_INTERVAL}
-    eos-draining-check-interval = ${?AKKA_KAFKA_CONSUMER_EOS_DRAINING_CHECK_INTERVAL}
-    connection-checker = {
-        enable = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_ENABLE}
-        max-retries = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_MAX_RETRIES}
-        backoff-factor = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_BACKOFF_FACTOR}
-        check-interval = ${?AKKA_KAFKA_CONSUMER_CONNECTION_CHECKER_CHECK_INTERVAL}
-    }
-    partition-handler-warning = ${?AKKA_KAFKA_CONSUMER_PARTITION_HANDLER_WARNING}
-    offset-reset-protection = {
-        enable = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_ENABLE}
-        offset-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_OFFSET_THRESHOLD}
-        time-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_TIME_THRESHOLD}
-    }
-}
-
-akka.kafka.producer {
-    discovery-method = ${?AKKA_KAFKA_PRODUCER_DISCOVERY_METHOD}
-    service-name = ${?AKKA_KAFKA_PRODUCER_SERVICE_NAME}
-    resolve-timeout = ${?AKKA_KAFKA_PRODUCER_RESOLVE_TIMEOUT}
-    parallelism = ${?AKKA_KAFKA_PRODUCER_PARALLELISM}
-    close-timeout = ${?AKKA_KAFKA_PRODUCER_CLOSE_TIMEOUT}
-    close-on-producer-stop = ${?AKKA_KAFKA_PRODUCER_CLOSE_ON_PRODUCER_STOP}
-    use-dispatcher = ${?AKKA_KAFKA_PRODUCER_USE_DISPATCHER}
-    eos-commit-interval = ${?AKKA_KAFKA_PRODUCER_EOS_COMMIT_INTERVAL}
-}
-
-kafka-client = {
-    bootstrap.servers = ${?KAFKA_CLIENT_BOOTSTRAP_SERVERS}
-}
-
-akka.kafka.committer = {
-    max-batch = 100000
-    max-batch = ${?AKKA_KAFKA_COMMITTER_MAX_BATCH}
-    max-interval = 1 hour
-    max-interval = ${?AKKA_KAFKA_COMMITTER_MAX_INTERVAL}
-    parallelism = ${?AKKA_KAFKA_COMMITTER_PARALLELISM}
-    parallelism = 10000
-}
-
 kafka-cluster = {
     topics = []
     topics = ${?KAFKA_CLUSTER_TOPICS}

--- a/docs/src/main/paradox/backup/configuration.md
+++ b/docs/src/main/paradox/backup/configuration.md
@@ -8,17 +8,21 @@ Scala API doc @apidoc[kafka.backup.configs.Backup]
 
 ## Explanation
 
-* `kafka-group-id`: The group id for the Kafka consumer that's used in restore tool
-* `time-configuration`: How to slice the persisted keys/files based by time
-    * `type`: The type of time configuration. Either `period-from-first` or `chrono-unit-slice`
-        * `period-from-first`: Guardian will split up the backup keys/files determined by the `duration` specified. The
-          key/filename will be determined by the timestamp of the first message received from the Kafka consumer with
-          each further key/filename being incremented by the configured `duration`. If guardian is shut down then it
-          will terminate and complete stream with the final element in the JSON array being a `null`
-            * This is done so it's possible to determine if a backup has been terminated by shut down of Guardian and
-              also because it's not really possible to resume using arbitrary durations.
-        * `chrono-unit-slice`: Guardian will split up the backup keys/files determined by the `chrono-unit` which
-          represent intervals such as days and weeks. As such when using this setting its possible for Guardian to
-          resume from a previous uncompleted backup.
-    * `duration`: If configuration is `period-from-first` then this determines max period of time for each time slice.
-    * `chrono-unit`: if configuration is `chrono-unit-slice` the `chrono-unit` determines
+* `akka.kafka.consumer`: See @extref:[documentation](alpakka-kafka-docs:consumer.html#settings)
+* `akka.kafka.consumer.kafka-clients`: See @extref:[documentation](kafka-docs:documentation.html#consumerconfigs)
+* `backup`:
+    * `kafka-group-id`: The group id for the Kafka consumer that's used in restore tool
+    * `time-configuration`: How to slice the persisted keys/files based by time
+        * `type`: The type of time configuration. Either `period-from-first` or `chrono-unit-slice`
+            * `period-from-first`: Guardian will split up the backup keys/files determined by the `duration` specified.
+              The key/filename will be determined by the timestamp of the first message received from the Kafka consumer
+              with each further key/filename being incremented by the configured `duration`. If guardian is shut down
+              then it will terminate and complete stream with the final element in the JSON array being a `null`
+                * This is done so it's possible to determine if a backup has been terminated by shut down of Guardian
+                  and also because it's not really possible to resume using arbitrary durations.
+            * `chrono-unit-slice`: Guardian will split up the backup keys/files determined by the `chrono-unit` which
+              represent intervals such as days and weeks. As such when using this setting its possible for Guardian to
+              resume from a previous uncompleted backup.
+        * `duration`: If configuration is `period-from-first` then this determines max period of time for each time
+          slice.
+        * `chrono-unit`: if configuration is `chrono-unit-slice` the `chrono-unit` determines

--- a/docs/src/main/paradox/restore/configuration.md
+++ b/docs/src/main/paradox/restore/configuration.md
@@ -8,6 +8,9 @@ Scala API doc @apidoc[kafka.restore.configs.Restore]
 
 ## Explanation
 
-* `from-when`: An `ISO-8601` time that specifies from when topics need to be restored. Note that the time used is based
-  on the original Kafka timestamp and **NOT** the current time.
-* `override-topics`: A mapping of currently backed up topics to a new topic in the destination Kafka cluster
+* `akka.kafka.producer`: See @extref:[documentation](alpakka-kafka-docs:producer.html#settings)
+* `akka.kafka.producer.kafka-clients`: See @extref:[documentation](kafka-docs:documentation.html#producerconfigs)
+* `restore`:
+    * `from-when`: An `ISO-8601` time that specifies from when topics need to be restored. Note that the time used is
+      based on the original Kafka timestamp and **NOT** the current time.
+    * `override-topics`: A mapping of currently backed up topics to a new topic in the destination Kafka cluster


### PR DESCRIPTION
# About this change - What it does

This PR fixes up how the kafka-clients (i.e. configuration specifically for the underlying official Java Kafka Client) configuration is applied.

# Why this way

In summary this PR fixes the issue of passing in configuration via either environment variables or java system properties into the underlying official Kafka client. This is necessary for settings such as ssl/tls, username, password etc etc. This is especially important given that as of now, the cli tool doesn't let you set these settings via command line arguments (its an open point about which command line arguments the cli tool/s should provide)

Notes:
* A lot of settings from the main `core` `reference.conf` was moved to the respective modules so that the documentation could correctly display which `reference.conf` settings are relevant for the project, i.e. `akka.kafka.consumer` was moved to the `core-backup` module (since `core-backup` is the module that uses a kafka consumer to read messages) and this also means the documentation in that refers to `core-backup` also has these settings
* The documentation has also been updated to reflect these changes. Importantly settings that refer to official Kafka client (i.e. `akka.kafka.consumer.kafka-clients` points to the official Kafka documentation at https://kafka.apache.org/30/documentation.html#consumerconfigs).
  * Unfortunately in order for this documentation to work we had to explicitly set the Kafka version in `build.sbt` because afaik SBT has no way to programatically (within `build.sbt`) find out a transitive dependency (in this case from `akka-streams-kafka`). This is not ideal because `akka-streams-kafka` is only tested/verified with the version of kafka clients that it ships with but it requires changes to SBT to fix properly.
* The common kafka configs such as `kafka-client.bootstrap.servers` don't actually work with Alpakka's kafka client since Alpakka explicitly passes in the configuration to the official Kafka client. Due to this the CLI tools don't check if this config is set since it doesn't do anything.

I have tested this PR by exporting variables such as `AKKA_KAFKA_CONSUMER_KAFKA_CLIENTS.bootstrap.servers` and it works as expected.