### PR TITLE
Enable sbt-paradox-project-info

### DIFF
--- a/docs/src/main/paradox/backup/design.md
+++ b/docs/src/main/paradox/backup/design.md
@@ -1,0 +1,22 @@
+# Design
+
+The format for backups is in JSON consisting of a large JSON array filled with JSON objects that have the following
+format.
+
+```json
+{
+  "topic": "kafka topic",
+  "partition": 0,
+  "offset": 0,
+  "key": "a2V5",
+  "value": "dmFsdWU=",
+  "timestamp": 0,
+  "timestamp_type": 0
+}
+```
+
+The `key` and `value` are Base64 encoded byte arrays (in the above example `"a2V5"` decodes to the string `key`
+and `"dmFsdWU="` decodes to the string `value`). This is due to the fact that the backup tool can make no assumptions on
+the format of the key or value, so we encode the raw byte arrays.
+
+One thing to note is that its possible for the last JSON object in the JSON array to be `null`, see for more info.

--- a/docs/src/main/paradox/backup/index.md
+++ b/docs/src/main/paradox/backup/index.md
@@ -1,31 +1,15 @@
 # Backup
 
 The backup module is responsible for backing up a specific set of Kafka topics into a persistent storage. The backup
-runs as a continuous stream that is split depending on time buckets which are configurable. The format for backups is in
-JSON consisting of a large JSON array filled with JSON objects that have the following format.
+runs as a continuous stream that is split depending on time buckets which are configurable.
 
-```json
-{
-  "topic": "kafka topic",
-  "partition": 0,
-  "offset": 0,
-  "key": "a2V5",
-  "value": "dmFsdWU=",
-  "timestamp": 0,
-  "timestamp_type": 0
-}
-```
-
-The `key` and `value` are Base64 encoded byte arrays (in the above example `"a2V5"` decodes to the string `key`
-and `"dmFsdWU="` decodes to the string `value`). This is due to the fact that the backup tool can make no assumptions on
-the format of the key or value, so we encode the raw byte arrays.
-
-One thing to note is that its possible for the last JSON object in the JSON array to be `null`, see for more info.
+@@project-info { projectId="coreBackup" }
 
 @@toc { depth=2 }
 
 @@@ index
 
 * [configuration](configuration.md)
+* [design](design.md)
 
 @@@

--- a/docs/src/main/paradox/persistence/s3/index.md
+++ b/docs/src/main/paradox/persistence/s3/index.md
@@ -2,6 +2,8 @@
 
 The S3 persistence module allows you to store kafka backups on [AWS S3 Cloud Storage](https://aws.amazon.com/s3/).
 
+@@project-info { projectId="coreS3" }
+
 @@toc { depth=2 }
 
 @@@ index
@@ -9,4 +11,3 @@ The S3 persistence module allows you to store kafka backups on [AWS S3 Cloud Sto
 * [configuration](configuration.md)
 
 @@@
-

--- a/docs/src/main/paradox/restore/index.md
+++ b/docs/src/main/paradox/restore/index.md
@@ -4,6 +4,8 @@ The restore module is responsible for streaming data from a backup storage locat
 circumstance of a disaster recovery. The restore is able to work in any format of backed up files created by Guardian's
 restore.
 
+@@project-info { projectId="coreRestore" }
+
 @@toc { depth=2 }
 
 @@@ index

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"             % "2.4.6")
 addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"              % "0.9.2")
 addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-apidoc"       % "0.10+12-1d5b87db")
-addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-project-info" % "1.1.4")
+addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-project-info" % "1.1.10")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"               % "0.5.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-ghpages"              % "0.6.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"         % "3.0.0+82-b1fe858b")

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -4,11 +4,6 @@ project-info {
   scaladoc: "https://doc.akka.io/api/alpakka/"${project-info.version}"/akka/stream/alpakka/"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 11", "Adopt OpenJDK 17"]
-    snapshots: {
-      url: "other-docs/snapshots.html"
-      text: "Snapshots are available"
-      new-tab: false
-    }
     issues: {
       url: "https://github.com/aiven/guardian-for-apache-kafka/issues"
       text: "Github issues"


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This PR enables sbt-paradox-project-info by using the latest release

# Why this way

In the previous release of sbt-paradox-project-info the `levels` field was mandatory and hence it couldn't be omitted. I resolved this in the latest release which means we can now enable sbt-paradox-project-info.

The PR also moves info about `backup` from `index.md` to `design.md` since it make more sense there.
