### PR TITLE
Load KafkaClients configuration via properties file

### DIFF
--- a/core-backup/src/main/resources/reference.conf
+++ b/core-backup/src/main/resources/reference.conf
@@ -24,9 +24,6 @@ akka.kafka.consumer = {
         offset-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_OFFSET_THRESHOLD}
         time-threshold = ${?AKKA_KAFKA_CONSUMER_OFFSET_RESET_PROTECTION_TIME_THRESHOLD}
     }
-
-    # Configurations for org.apache.kafka.clients.consumer.ConsumerConfig
-    kafka-clients = ${?AKKA_KAFKA_CONSUMER_KAFKA_CLIENTS}
 }
 
 akka.kafka.committer = {

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/arguments/PropertiesOpt.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/arguments/PropertiesOpt.scala
@@ -1,0 +1,34 @@
+package io.aiven.guardian.cli.arguments
+
+import cats.data.ValidatedNel
+import cats.implicits._
+import com.monovore.decline.Argument
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Using
+
+import java.io.BufferedReader
+import java.io.FileNotFoundException
+import java.io.FileReader
+import java.util.Properties
+
+object PropertiesOpt {
+  implicit val propertiesArgument: Argument[Properties] = new Argument[Properties] {
+    override def read(string: String): ValidatedNel[String, Properties] = {
+      val prop = new Properties()
+      Using(new BufferedReader(new FileReader(string))) { reader =>
+        prop.load(reader)
+      } match {
+        case Failure(_: FileNotFoundException) =>
+          s"Properties file at path $string does not exist".invalidNel
+        case Failure(_) =>
+          s"Unable to read file at path $string".invalidNel
+        case Success(_) => prop.validNel
+      }
+    }
+
+    override def defaultMetavar: String = "path"
+  }
+
+}


### PR DESCRIPTION
# About this change - What it does
Adds a cli argument that allows loading the underlying KafkaClients properties via a `.properties` file.

# Why this way

It turns out there isn't a way to override an entire Typesafe config object using environment variables that is ideal. Due to this the change makes it so you can supply a `.properties` file (which is standard for the Java kafka clients file).