### PR TITLE
Log errors if a stream terminates unexpectedly

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -3,6 +3,9 @@ package io.aiven.guardian.kafka.backup
 import akka.Done
 import akka.actor.ActorSystem
 import akka.kafka.scaladsl.Consumer
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
+import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.backup.BackupClientInterface
 import io.aiven.guardian.kafka.backup.KafkaClient
 import io.aiven.guardian.kafka.backup.KafkaClientInterface
@@ -10,13 +13,21 @@ import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-trait App[T <: KafkaClientInterface] {
+trait App[T <: KafkaClientInterface] extends StrictLogging {
   implicit val kafkaClient: T
   implicit val backupClient: BackupClientInterface[KafkaClient]
   implicit val actorSystem: ActorSystem
   implicit val executionContext: ExecutionContext
 
-  def run(): Consumer.Control = backupClient.backup.run()
+  def run(): Consumer.Control = {
+    val decider: Supervision.Decider = { e =>
+      logger.error("Unhandled exception in stream", e)
+      Supervision.Stop
+    }
+
+    backupClient.backup.withAttributes(ActorAttributes.supervisionStrategy(decider)).run()
+  }
+
   def shutdown(control: Consumer.Control): Future[Done] =
     // Ideally we should be using drainAndShutdown however this isn't possible due to
     // https://github.com/aiven/guardian-for-apache-kafka/issues/80

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
@@ -1,11 +1,22 @@
 package io.aiven.guardian.kafka.restore
 
+import akka.stream.{ActorAttributes, Attributes, Supervision}
 import akka.stream.alpakka.s3.S3Settings
+import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.restore.s3.RestoreClient
 import io.aiven.guardian.kafka.s3.{Config => S3Config}
 
-trait S3App extends S3Config with RestoreApp with App {
+trait S3App extends S3Config with RestoreApp with App with StrictLogging {
   lazy val s3Settings: S3Settings = S3Settings()
   implicit lazy val restoreClient: RestoreClient[KafkaProducer] =
-    new RestoreClient[KafkaProducer](Some(s3Settings), maybeKillSwitch)
+    new RestoreClient[KafkaProducer](Some(s3Settings), maybeKillSwitch) {
+      override val maybeAttributes: Some[Attributes] = {
+        val decider: Supervision.Decider = { e =>
+          logger.error("Unhandled exception in stream", e)
+          Supervision.Stop
+        }
+
+        Some(ActorAttributes.supervisionStrategy(decider))
+      }
+    }
 }

--- a/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreClientInterface.scala
+++ b/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreClientInterface.scala
@@ -3,6 +3,7 @@ package io.aiven.guardian.kafka.restore
 import akka.Done
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.Attributes
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
@@ -28,6 +29,7 @@ trait RestoreClientInterface[T <: KafkaProducerInterface] extends StrictLogging 
   implicit val kafkaClusterConfig: KafkaCluster
   implicit val system: ActorSystem
   val maybeKillSwitch: Option[SharedKillSwitch]
+  val maybeAttributes: Option[Attributes] = None
 
   def retrieveBackupKeys: Future[List[String]]
 


### PR DESCRIPTION
# About this change - What it does

Logs errors if an uncaught exception is thrown in one of the streams

# Why this way

The solution for the `cli-restore` is not that typical but that is due to https://github.com/typelevel/jawn/pull/438  and https://discuss.lightbend.com/t/working-with-eof-for-a-source-flow/9481 
