### PR TITLE
Prevent cli-backup from immediately terminating

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -28,8 +28,10 @@ trait App[T <: KafkaClientInterface] extends StrictLogging {
     backupClient.backup.withAttributes(ActorAttributes.supervisionStrategy(decider)).run()
   }
 
-  def shutdown(control: Consumer.Control): Future[Done] =
+  def shutdown(control: Consumer.Control): Future[Done] = {
+    logger.warn("Shutdown of Guardian detected")
     // Ideally we should be using drainAndShutdown however this isn't possible due to
     // https://github.com/aiven/guardian-for-apache-kafka/issues/80
     control.stop().flatMap(_ => control.shutdown())
+  }
 }

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
@@ -1,6 +1,8 @@
 package io.aiven.guardian.kafka.restore
 
-import akka.stream.{ActorAttributes, Attributes, Supervision}
+import akka.stream.ActorAttributes
+import akka.stream.Attributes
+import akka.stream.Supervision
 import akka.stream.alpakka.s3.S3Settings
 import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.restore.s3.RestoreClient

--- a/core-restore/src/main/resources/reference.conf
+++ b/core-restore/src/main/resources/reference.conf
@@ -7,9 +7,6 @@ akka.kafka.producer {
     close-on-producer-stop = ${?AKKA_KAFKA_PRODUCER_CLOSE_ON_PRODUCER_STOP}
     use-dispatcher = ${?AKKA_KAFKA_PRODUCER_USE_DISPATCHER}
     eos-commit-interval = ${?AKKA_KAFKA_PRODUCER_EOS_COMMIT_INTERVAL}
-
-    # Configurations for org.apache.kafka.clients.producer.ProducerConfig
-    kafka-clients = ${?AKKA_KAFKA_PRODUCER_KAFKA_CLIENTS}
 }
 
 restore {


### PR DESCRIPTION
# About this change - What it does

Fixes the problem where cli-backup was immediately terminated. Also added a log message when a shutdown is detected
