### PR TITLE
Update never terminate logic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,18 +36,20 @@ val flagsFor12 = Seq(
   "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
   "-Ywarn-inaccessible",
   "-Ywarn-infer-any",
+  "-language:existentials",
   "-opt-inline-from:<sources>",
   "-opt:l:method"
 )
 
 val flagsFor13 = Seq(
   "-Xlint:_",
-  "-opt-inline-from:<sources>",
-  "-opt:l:method",
   "-Xfatal-warnings",
   "-Ywarn-unused",
   "-Xlint:adapted-args",
-  "-Wconf:cat=unused:info"
+  "-Wconf:cat=unused:info",
+  "-language:existentials",
+  "-opt-inline-from:<sources>",
+  "-opt:l:method"
 )
 
 val librarySettings = Seq(

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -29,7 +29,7 @@ trait App[T <: KafkaClientInterface] extends StrictLogging {
   }
 
   def shutdown(control: Consumer.Control): Future[Done] = {
-    logger.warn("Shutdown of Guardian detected")
+    logger.info("Shutdown of Guardian detected")
     // Ideally we should be using drainAndShutdown however this isn't possible due to
     // https://github.com/aiven/guardian-for-apache-kafka/issues/80
     control.stop().flatMap(_ => control.shutdown())

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/Main.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/Main.scala
@@ -159,7 +159,7 @@ class Entry(val initializedApp: AtomicReference[Option[App]] = new AtomicReferen
           }
           initializedApp.set(Some(app))
           Runtime.getRuntime.addShutdownHook(new Thread {
-            logger.warn("Shutdown of Guardian detected")
+            logger.info("Shutdown of Guardian detected")
             killSwitch.shutdown()
             Await.result(app.actorSystem.terminate(), 5 minutes)
           })

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/MainUtils.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/MainUtils.scala
@@ -1,0 +1,33 @@
+package io.aiven.guardian.cli
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.blocking
+import scala.io.StdIn
+
+object MainUtils {
+
+  /** Hook that lets the user specify the future that will signal the shutdown of the server whenever completed. Adapted
+    * from
+    * https://github.com/akka/akka-http/blob/main/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala#L151-L163
+    */
+  @SuppressWarnings(
+    Array(
+      "scalafix:DisableSyntax.null"
+    )
+  )
+  def waitForShutdownSignal(promise: Promise[Unit] = Promise[Unit]())(implicit ec: ExecutionContext): Future[Unit] = {
+    sys.addShutdownHook {
+      promise.trySuccess(())
+    }
+    Future {
+      blocking {
+        if (StdIn.readLine("Press RETURN to stop...\n") != null)
+          promise.trySuccess(())
+      }
+    }
+    promise.future
+  }
+
+}


### PR DESCRIPTION
# About this change - What it does

The https://github.com/aiven/guardian-for-apache-kafka/pull/165 PR didn't completely correctly implement the logic where the CLI backup never terminates.
