### PR TITLE
Handle null keys

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -13,10 +13,12 @@ import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import io.aiven.guardian.kafka.s3.configs.S3
 
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.Await
+import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
+
 import java.time.temporal.ChronoUnit
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicReference

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -108,7 +108,7 @@ object KafkaClient {
       consumerRecord.topic(),
       consumerRecord.partition(),
       consumerRecord.offset(),
-      Base64.getEncoder.encodeToString(consumerRecord.key()),
+      Option(consumerRecord.key()).map(byteArray => Base64.getEncoder.encodeToString(byteArray)),
       Base64.getEncoder.encodeToString(consumerRecord.value()),
       consumerRecord.timestamp(),
       consumerRecord.timestampType()

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -190,7 +190,7 @@ class BackupClientInterfaceSpec
   }
 
   property("backup method completes flow correctly for single element") {
-    val reducedConsumerRecord = ReducedConsumerRecord("", 0, 1, "key", "value", 1, TimestampType.CREATE_TIME)
+    val reducedConsumerRecord = ReducedConsumerRecord("", 0, 1, Some("key"), "value", 1, TimestampType.CREATE_TIME)
 
     val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source.single(
                                                                     reducedConsumerRecord
@@ -224,8 +224,8 @@ class BackupClientInterfaceSpec
 
   property("backup method completes flow correctly for two elements") {
     val reducedConsumerRecords = List(
-      ReducedConsumerRecord("", 0, 1, "key", "value1", 1, TimestampType.CREATE_TIME),
-      ReducedConsumerRecord("", 0, 2, "key", "value2", 2, TimestampType.CREATE_TIME)
+      ReducedConsumerRecord("", 0, 1, Some("key"), "value1", 1, TimestampType.CREATE_TIME),
+      ReducedConsumerRecord("", 0, 2, Some("key"), "value2", 2, TimestampType.CREATE_TIME)
     )
 
     val mock = new MockedBackupClientInterfaceWithMockedKafkaData(Source(

--- a/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/KafkaProducer.scala
+++ b/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/KafkaProducer.scala
@@ -34,10 +34,19 @@ class KafkaProducer(
           map.getOrElse(reducedConsumerRecord.topic, reducedConsumerRecord.topic)
         case None => reducedConsumerRecord.topic
       }
-      new ProducerRecord[Array[Byte], Array[Byte]](
-        topic,
-        Base64.getDecoder.decode(reducedConsumerRecord.key),
-        Base64.getDecoder.decode(reducedConsumerRecord.value)
-      )
+      val valueAsByteArray = Base64.getDecoder.decode(reducedConsumerRecord.value)
+      reducedConsumerRecord.key match {
+        case Some(key) =>
+          new ProducerRecord[Array[Byte], Array[Byte]](
+            topic,
+            Base64.getDecoder.decode(key),
+            valueAsByteArray
+          )
+        case None =>
+          new ProducerRecord[Array[Byte], Array[Byte]](
+            topic,
+            valueAsByteArray
+          )
+      }
     }
 }

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -188,8 +188,15 @@ trait S3Spec
     */
   def toProducerRecords(data: List[ReducedConsumerRecord]): List[ProducerRecord[Array[Byte], Array[Byte]]] = data.map {
     reducedConsumerRecord =>
-      val keyAsByteArray   = Base64.getDecoder.decode(reducedConsumerRecord.key)
       val valueAsByteArray = Base64.getDecoder.decode(reducedConsumerRecord.value)
-      new ProducerRecord[Array[Byte], Array[Byte]](reducedConsumerRecord.topic, keyAsByteArray, valueAsByteArray)
+      reducedConsumerRecord.key match {
+        case Some(key) =>
+          new ProducerRecord[Array[Byte], Array[Byte]](reducedConsumerRecord.topic,
+                                                       Base64.getDecoder.decode(key),
+                                                       valueAsByteArray
+          )
+        case None =>
+          new ProducerRecord[Array[Byte], Array[Byte]](reducedConsumerRecord.topic, valueAsByteArray)
+      }
   }
 }

--- a/core/src/main/scala/io/aiven/guardian/kafka/models/ReducedConsumerRecord.scala
+++ b/core/src/main/scala/io/aiven/guardian/kafka/models/ReducedConsumerRecord.scala
@@ -24,7 +24,7 @@ import java.time.ZoneId
 final case class ReducedConsumerRecord(topic: String,
                                        partition: Int,
                                        offset: Long,
-                                       key: String,
+                                       key: Option[String],
                                        value: String,
                                        timestamp: Long,
                                        timestampType: TimestampType

--- a/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
@@ -30,7 +30,7 @@ object Generators {
     t,
     p,
     o,
-    k,
+    Some(k),
     value,
     ts,
     timestampType


### PR DESCRIPTION
# About this change - What it does

Add functionality to handle the case where the kafka `ProducerRecord` key happens to be null

# Why this way

Self explanatory, forgot to handle this case. Note that at some point in future we should add tests to handle the case where the `key` is null.
