### PR TITLE
Set commit-timeout based on timeConfiguration

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
@@ -12,15 +12,19 @@ import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 class MockedS3BackupClientInterface(
     kafkaData: Source[ReducedConsumerRecord, NotUsed],
     timeConfiguration: TimeConfiguration,
     s3Config: S3Config,
     maybeS3Settings: Option[S3Settings]
 )(implicit val s3Headers: S3Headers, system: ActorSystem)
-    extends BackupClient(maybeS3Settings)(new MockedKafkaClientInterface(kafkaData),
-                                          Backup(MockedBackupClientInterface.KafkaGroupId, timeConfiguration),
-                                          implicitly,
-                                          s3Config,
-                                          implicitly
+    extends BackupClient(maybeS3Settings)(
+      new MockedKafkaClientInterface(kafkaData),
+      Backup(MockedBackupClientInterface.KafkaGroupId, timeConfiguration, 10 seconds),
+      implicitly,
+      s3Config,
+      implicitly
     )

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -99,8 +99,9 @@ class RealS3BackupClientSpec
 
       implicit val kafkaClusterConfig: KafkaCluster = KafkaCluster(topics)
 
-      implicit val config: S3Config     = s3Config
-      implicit val backupConfig: Backup = Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute))
+      implicit val config: S3Config = s3Config
+      implicit val backupConfig: Backup =
+        Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute), 10 seconds)
 
       val producerSettings = createProducer()
 
@@ -180,8 +181,9 @@ class RealS3BackupClientSpec
 
       implicit val kafkaClusterConfig: KafkaCluster = KafkaCluster(topics)
 
-      implicit val config: S3Config     = s3Config
-      implicit val backupConfig: Backup = Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute))
+      implicit val config: S3Config = s3Config
+      implicit val backupConfig: Backup =
+        Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute), 10 seconds)
 
       val producerSettings = createProducer()
 
@@ -317,7 +319,7 @@ class RealS3BackupClientSpec
 
       implicit val config: S3Config = s3Config
       implicit val backupConfig: Backup =
-        Backup(MockedBackupClientInterface.KafkaGroupId, ChronoUnitSlice(ChronoUnit.MINUTES))
+        Backup(MockedBackupClientInterface.KafkaGroupId, ChronoUnitSlice(ChronoUnit.MINUTES), 10 seconds)
 
       val producerSettings = createProducer()
 

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -47,7 +47,7 @@ class Entry(val initializedApp: AtomicReference[Option[(App[_], Promise[Unit])]]
 
         val commitTimeoutBufferOpt =
           Opts
-            .option[FiniteDuration]("commit-timeout-buffer",
+            .option[FiniteDuration]("commit-timeout-buffer-window",
                                     help =
                                       "A buffer that gets added onto the commit timeout configuration for the consumer"
             )

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -45,17 +45,26 @@ class Entry(val initializedApp: AtomicReference[Option[(App[_], Promise[Unit])]]
         val timeConfigurationOpt: Opts[Option[TimeConfiguration]] =
           (periodFromFirstOpt orElse chronoUnitSliceOpt).orNone
 
+        val commitTimeoutBufferOpt =
+          Opts
+            .option[FiniteDuration]("commit-timeout-buffer",
+                                    help =
+                                      "A buffer that gets added onto the commit timeout configuration for the consumer"
+            )
+            .withDefault(10 seconds)
+
         val backupOpt =
-          (groupIdOpt, timeConfigurationOpt).tupled.mapValidated { case (maybeGroupId, maybeTimeConfiguration) =>
-            import io.aiven.guardian.kafka.backup.Config.backupConfig
-            (maybeGroupId, maybeTimeConfiguration) match {
-              case (Some(groupId), Some(timeConfiguration)) =>
-                Backup(groupId, timeConfiguration).validNel
-              case _ =>
-                Options
-                  .optionalPureConfigValue(() => backupConfig)
-                  .toValidNel("Backup config is a mandatory value that needs to be configured")
-            }
+          (groupIdOpt, timeConfigurationOpt, commitTimeoutBufferOpt).tupled.mapValidated {
+            case (maybeGroupId, maybeTimeConfiguration, commitTimeoutBuffer) =>
+              import io.aiven.guardian.kafka.backup.Config.backupConfig
+              (maybeGroupId, maybeTimeConfiguration) match {
+                case (Some(groupId), Some(timeConfiguration)) =>
+                  Backup(groupId, timeConfiguration, commitTimeoutBuffer).validNel
+                case _ =>
+                  Options
+                    .optionalPureConfigValue(() => backupConfig)
+                    .toValidNel("Backup config is a mandatory value that needs to be configured")
+              }
           }
 
         val s3Opt = Options.dataBucketOpt.mapValidated { maybeDataBucket =>

--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
@@ -44,7 +44,7 @@ class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike
       groupId,
       "--chrono-unit-slice",
       "hours",
-      "--commit-timeout-buffer",
+      "--commit-timeout-buffer-window",
       "1 second"
     )
 

--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/CliSpec.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 
 @nowarn("msg=method main in class CommandApp is deprecated")
 class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike with Matchers with ScalaFutures {
@@ -42,7 +43,9 @@ class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike
       "--kafka-group-id",
       groupId,
       "--chrono-unit-slice",
-      "hours"
+      "hours",
+      "--commit-timeout-buffer",
+      "1 second"
     )
 
     Future {
@@ -62,7 +65,10 @@ class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike
     promise.success(())
     app match {
       case s3App: S3App =>
-        s3App.backupConfig mustEqual BackupConfig(groupId, ChronoUnitSlice(ChronoUnit.HOURS))
+        s3App.backupConfig mustEqual BackupConfig(groupId,
+                                                  ChronoUnitSlice(ChronoUnit.HOURS),
+                                                  FiniteDuration(1, TimeUnit.SECONDS)
+        )
         s3App.kafkaClusterConfig mustEqual KafkaClusterConfig(Set(topic))
         s3App.kafkaClient.consumerSettings.getProperty("bootstrap.servers") mustEqual bootstrapServer
         s3App.s3Config.dataBucket mustEqual dataBucket

--- a/core-backup/src/main/resources/reference.conf
+++ b/core-backup/src/main/resources/reference.conf
@@ -3,7 +3,6 @@ akka.kafka.consumer = {
     poll-timeout = ${?AKKA_KAFKA_CONSUMER_POLL_TIMEOUT}
     stop-timeout = ${?AKKA_KAFKA_CONSUMER_STOP_TIMEOUT}
     close-timeout = ${?AKKA_KAFKA_CONSUMER_CLOSE_TIMEOUT}
-    commit-timeout = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIMEOUT}
     commit-time-warning = ${?AKKA_KAFKA_CONSUMER_COMMIT_TIME_WARNING}
     commit-refresh-interval = ${?AKKA_KAFKA_CONSUMER_COMMIT_REFRESH_INTERVAL}
     use-dispatcher = ${?AKKA_KAFKA_CONSUMER_USE_DISPATCHER}
@@ -45,4 +44,6 @@ backup {
        duration = 1 hour
        duration = ${?BACKUP_TIME_CONFIGURATION_DURATION}
     }
+    commit-timeout-buffer = 10 seconds
+    commit-timeout-buffer = ${?BACKUP_COMMIT_TIMEOUT_BUFFER}
 }

--- a/core-backup/src/main/resources/reference.conf
+++ b/core-backup/src/main/resources/reference.conf
@@ -44,6 +44,6 @@ backup {
        duration = 1 hour
        duration = ${?BACKUP_TIME_CONFIGURATION_DURATION}
     }
-    commit-timeout-buffer = 10 seconds
-    commit-timeout-buffer = ${?BACKUP_COMMIT_TIMEOUT_BUFFER}
+    commit-timeout-buffer-window = 10 seconds
+    commit-timeout-buffer-window = ${?BACKUP_COMMIT_TIMEOUT_BUFFER}
 }

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -73,7 +73,7 @@ class KafkaClient(
             chronoUnit.getDuration.toScala
         }
 
-        baseDuration + backupConfig.commitTimeoutBuffer
+        baseDuration + backupConfig.commitTimeoutBufferWindow
       }
       .withGroupId(
         backupConfig.kafkaGroupId

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
@@ -1,8 +1,12 @@
 package io.aiven.guardian.kafka.backup.configs
 
+import scala.concurrent.duration.FiniteDuration
+
 /** @param kafkaGroupId
   *   The group-id that the Kafka consumer will use
   * @param timeConfiguration
   *   Determines how the backed up objects/files are segregated depending on a time configuration
+  * @param commitTimeoutBuffer
+  *   A buffer that is added ontop of the `timeConfiguration` when setting the Kafka Consumer commit timeout.
   */
-final case class Backup(kafkaGroupId: String, timeConfiguration: TimeConfiguration)
+final case class Backup(kafkaGroupId: String, timeConfiguration: TimeConfiguration, commitTimeoutBuffer: FiniteDuration)

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/configs/Backup.scala
@@ -6,7 +6,10 @@ import scala.concurrent.duration.FiniteDuration
   *   The group-id that the Kafka consumer will use
   * @param timeConfiguration
   *   Determines how the backed up objects/files are segregated depending on a time configuration
-  * @param commitTimeoutBuffer
+  * @param commitTimeoutBufferWindow
   *   A buffer that is added ontop of the `timeConfiguration` when setting the Kafka Consumer commit timeout.
   */
-final case class Backup(kafkaGroupId: String, timeConfiguration: TimeConfiguration, commitTimeoutBuffer: FiniteDuration)
+final case class Backup(kafkaGroupId: String,
+                        timeConfiguration: TimeConfiguration,
+                        commitTimeoutBufferWindow: FiniteDuration
+)

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -15,7 +15,9 @@ import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.language.postfixOps
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -74,7 +76,8 @@ class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafka
 
   override implicit lazy val backupConfig: Backup = Backup(
     KafkaGroupId,
-    timeConfiguration
+    timeConfiguration,
+    10 seconds
   )
 
   /** Override this type to define the result of backing up data to a datasource

--- a/docs/src/main/paradox/backup/configuration.md
+++ b/docs/src/main/paradox/backup/configuration.md
@@ -26,3 +26,6 @@ Scala API doc @apidoc[kafka.backup.configs.Backup]
         * `duration`: If configuration is `period-from-first` then this determines max period of time for each time
           slice.
         * `chrono-unit`: if configuration is `chrono-unit-slice` the `chrono-unit` determines
+    * `commit-timeout-buffer`: Guardian sets the commit timeout of the Kafka consumer based on the `time-configuration`
+      since Guardian does manual committing of cursors. The buffer gets added onto the `time-configuration` to give
+      some headroom for any theoretical delays.

--- a/docs/src/main/paradox/backup/configuration.md
+++ b/docs/src/main/paradox/backup/configuration.md
@@ -26,6 +26,6 @@ Scala API doc @apidoc[kafka.backup.configs.Backup]
         * `duration`: If configuration is `period-from-first` then this determines max period of time for each time
           slice.
         * `chrono-unit`: if configuration is `chrono-unit-slice` the `chrono-unit` determines
-    * `commit-timeout-buffer`: Guardian sets the commit timeout of the Kafka consumer based on the `time-configuration`
+    * `commit-timeout-buffer-window`: Guardian sets the commit timeout of the Kafka consumer based on the `time-configuration`
       since Guardian does manual committing of cursors. The buffer gets added onto the `time-configuration` to give
       some headroom for any theoretical delays.

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
@@ -82,8 +82,9 @@ class RealS3RestoreClientSpec
         val asProducerRecords = toProducerRecords(data)
         val baseSource        = toSource(asProducerRecords, 30 seconds)
 
-        implicit val config: S3Config     = s3Config
-        implicit val backupConfig: Backup = Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute))
+        implicit val config: S3Config = s3Config
+        implicit val backupConfig: Backup =
+          Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 minute), 10 seconds)
 
         val backupClient =
           new BackupClient(Some(s3Settings))(new KafkaClient(configureConsumer = baseKafkaConfig),


### PR DESCRIPTION
# About this change - What it does

This PR sets the `commit-timeout` configuration for the Alpakka Kafka consumer to be based on the configured `time-configuration` plus an extra configurable `commit-timeout-buffer`

# Why this way

Since Guardian has manual control over committing cursors from read topics which it overrides it makes sense for Guardian to also set the `commit-timeout` option due to the fact that the user has no control over commit strategies. In other words, if you set a `time-configuration` of `1 minute` then the `commit-timeout` should be larger than that because Guardian will commit the cursor around every minute.

The `commit-timeout-buffer` is there to give us some headroom (delays in commits, latency between kafka cluster and the client since timestamp is based off Kafka's cluster timestamp etc etc). I set the buffer to a default of `10 seconds` as a ballpark figure but this can be changed afterwards.