### PR TITLE
Add timestamp to cli logging

### DIFF
--- a/core-cli/src/main/resources/logback.xml
+++ b/core-cli/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%highlight(%-5level)] %logger{0} - %msg%n</pattern>
+            <pattern>[%highlight(%-5level)] %d{HH:mm:ss.SSS} %logger{0} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
# About this change - What it does

Current CLI logging doesn't have a timestamp, this PR adds it.
