### PR TITLE
Improve logging for CLI

### DIFF
--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -15,7 +15,7 @@ import akka.stream.alpakka.s3.UploadPartResponse
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl._
 import akka.util.ByteString
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.backup.BackupClientInterface
 import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
@@ -34,7 +34,7 @@ class BackupClient[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings
     s3Config: S3Config,
     s3Headers: S3Headers
 ) extends BackupClientInterface[T]
-    with StrictLogging {
+    with LazyLogging {
   import BackupClient._
 
   override def empty: () => Future[Option[MultipartUploadResult]] = () => Future.successful(None)

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -6,7 +6,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
 import io.aiven.guardian.kafka.codecs.Circe._
@@ -25,7 +25,7 @@ import scala.language.postfixOps
 
 import java.time.OffsetDateTime
 
-trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll with StrictLogging {
+trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll with LazyLogging {
 
   val ThrottleElements: Int          = 100
   val ThrottleAmount: FiniteDuration = 1 millis

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorSystem
 import akka.kafka.scaladsl.Consumer
 import akka.stream.ActorAttributes
 import akka.stream.Supervision
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.backup.BackupClientInterface
 import io.aiven.guardian.kafka.backup.KafkaClient
 import io.aiven.guardian.kafka.backup.KafkaClientInterface
@@ -13,7 +13,7 @@ import io.aiven.guardian.kafka.backup.KafkaClientInterface
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-trait App[T <: KafkaClientInterface] extends StrictLogging {
+trait App[T <: KafkaClientInterface] extends LazyLogging {
   implicit val kafkaClient: T
   implicit val backupClient: BackupClientInterface[KafkaClient]
   implicit val actorSystem: ActorSystem

--- a/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
+++ b/cli-restore/src/main/scala/io/aiven/guardian/kafka/restore/S3App.scala
@@ -4,11 +4,11 @@ import akka.stream.ActorAttributes
 import akka.stream.Attributes
 import akka.stream.Supervision
 import akka.stream.alpakka.s3.S3Settings
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.restore.s3.RestoreClient
 import io.aiven.guardian.kafka.s3.{Config => S3Config}
 
-trait S3App extends S3Config with RestoreApp with App with StrictLogging {
+trait S3App extends S3Config with RestoreApp with App with LazyLogging {
   lazy val s3Settings: S3Settings = S3Settings()
   implicit lazy val restoreClient: RestoreClient[KafkaProducer] =
     new RestoreClient[KafkaProducer](Some(s3Settings), maybeKillSwitch) {

--- a/compaction-gcs/src/main/scala/io/aiven/guardian/kafka/compaction/gcs/StorageClient.scala
+++ b/compaction-gcs/src/main/scala/io/aiven/guardian/kafka/compaction/gcs/StorageClient.scala
@@ -3,7 +3,7 @@ package io.aiven.guardian.kafka.compaction.gcs
 import akka.NotUsed
 import akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage
 import akka.stream.scaladsl.Source
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.compaction.StorageInterface
 import io.aiven.guardian.kafka.compaction.gcs.models.StorageConfig
 import io.aiven.guardian.kafka.gcs.errors.GCSErrors
@@ -13,7 +13,7 @@ import scala.annotation.nowarn
 
 class StorageClient(bucketName: String, maybePrefix: Option[String])(implicit storageConfig: StorageConfig)
     extends StorageInterface
-    with StrictLogging {
+    with LazyLogging {
 
   /** Retrieve Kafka data from a given storage source
     *

--- a/compaction-s3/src/main/scala/io/aiven/guardian/kafka/compaction/s3/StorageClient.scala
+++ b/compaction-s3/src/main/scala/io/aiven/guardian/kafka/compaction/s3/StorageClient.scala
@@ -5,7 +5,7 @@ import akka.stream.alpakka.s3.BucketAccess
 import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.Source
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.compaction.StorageInterface
 import io.aiven.guardian.kafka.compaction.s3.models.StorageConfig
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
@@ -16,7 +16,7 @@ import scala.annotation.nowarn
 class StorageClient(bucketName: String, prefix: Option[String], s3Headers: S3Headers)(implicit
     storageConfig: StorageConfig
 ) extends StorageInterface
-    with StrictLogging {
+    with LazyLogging {
 
   /** Retrieve Kafka data from a given storage source
     *

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -12,7 +12,7 @@ import akka.kafka.scaladsl.Committer
 import akka.kafka.scaladsl.Consumer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.SourceWithContext
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
@@ -49,7 +49,7 @@ class KafkaClient(
     ] = None
 )(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster, backupConfig: Backup)
     extends KafkaClientInterface
-    with StrictLogging {
+    with LazyLogging {
   override type CursorContext        = CommittableOffset
   override type Control              = Consumer.Control
   override type BatchedCursorContext = CommittableOffsetBatch

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/MainUtils.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/MainUtils.scala
@@ -1,10 +1,20 @@
 package io.aiven.guardian.cli
 
+import ch.qos.logback.classic.joran.JoranConfigurator
+import ch.qos.logback.core.Context
+import org.slf4j.ILoggerFactory
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.blocking
 import scala.io.StdIn
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Using
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 object MainUtils {
 
@@ -29,5 +39,19 @@ object MainUtils {
     }
     promise.future
   }
+
+  /** Allows you to override the default logback.xml file with a custom one
+    * @see
+    *   https://stackoverflow.com/a/21886322/1519631
+    */
+  def setLogbackFile(path: Path, loggerContext: ILoggerFactory): Unit =
+    Using(Files.newInputStream(path)) { inputStream =>
+      val configurator = new JoranConfigurator
+      configurator.setContext(loggerContext.asInstanceOf[Context])
+      configurator.doConfigure(inputStream)
+    } match {
+      case Failure(exception) => throw exception
+      case Success(value)     => value
+    }
 
 }

--- a/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
@@ -9,6 +9,8 @@ import io.aiven.guardian.cli.arguments.StorageOpt
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import pureconfig.error.ConfigReaderException
 
+import java.nio.file.Path
+
 trait Options {
   val storageOpt: Opts[StorageOpt] =
     Opts.option[StorageOpt]("storage", help = "Which type of storage to persist kafka topics")
@@ -21,6 +23,9 @@ trait Options {
 
   val bootstrapServersOpt: Opts[Option[NonEmptyList[String]]] =
     Opts.options[String]("kafka-bootstrap-servers", help = "Kafka bootstrap servers").orNone
+
+  val logbackFileOpt: Opts[Option[Path]] =
+    Opts.option[Path]("logback-file", help = "Specify logback.xml configuration to override default").orNone
 
   def optionalPureConfigValue[T](value: () => T): Option[T] =
     try Some(value())

--- a/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreClientInterface.scala
+++ b/core-restore/src/main/scala/io/aiven/guardian/kafka/restore/RestoreClientInterface.scala
@@ -8,7 +8,7 @@ import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.ExtensionsMethods._
 import io.aiven.guardian.kafka.Utils
 import io.aiven.guardian.kafka.codecs.Circe._
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 
 import java.time.OffsetDateTime
 
-trait RestoreClientInterface[T <: KafkaProducerInterface] extends StrictLogging {
+trait RestoreClientInterface[T <: KafkaProducerInterface] extends LazyLogging {
   implicit val kafkaProducerInterface: T
   implicit val restoreConfig: Restore
   implicit val kafkaClusterConfig: KafkaCluster

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -11,7 +11,7 @@ import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.testkit.TestKitBase
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.akka.AkkaHttpTestKit
 import io.aiven.guardian.kafka.TestUtils
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
@@ -39,7 +39,7 @@ trait S3Spec
     with ScalaCheckPropertyChecks
     with ScalaFutures
     with Config
-    with StrictLogging {
+    with LazyLogging {
 
   // See https://stackoverflow.com/a/38834773
   case object RealS3Available


### PR DESCRIPTION
# About this change - What it does

Improves logging by adding some DEBUG statements but mainly allowing the `cli` tool to specify an alternative `logback.xml` (so you can turn on `DEBUG` level logging for example)

# Why this way
Changes are self explanatory but here are some notes

* `StrictLogging` was changed to `LazyLogging` to ensure that the `logger` class gets initialized after configuring the `logback` file (`LazyLogging` just assigns the `logger` to a `lazy val` so it only initializes the first time `logger` is referenced). I am not sure this is strictly necessary but its best to be safe
* Unfortunately due to the design of logback, testing that the configuration has changed successfully is not trivial. I tried this out locally and can confirm it works but we would have to use some other logging library to properly test for these things.
