### PR TITLE
Move CliSpec's to to their respective package

### DIFF
--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/backup/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/backup/CliSpec.scala
@@ -1,8 +1,7 @@
-package io.aiven.guardian.kafka
+package io.aiven.guardian.kafka.backup
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import io.aiven.guardian.kafka.backup.S3App
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.{Backup => BackupConfig}
 import io.aiven.guardian.kafka.configs.{KafkaCluster => KafkaClusterConfig}
@@ -49,18 +48,18 @@ class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike
     )
 
     Future {
-      backup.Main.main(args.toArray)
+      Main.main(args.toArray)
     }.recover { case _: Throwable =>
       ()
     }
 
-    def checkUntilMainInitialized(main: io.aiven.guardian.kafka.backup.Entry): Future[(backup.App[_], Promise[Unit])] =
+    def checkUntilMainInitialized(main: io.aiven.guardian.kafka.backup.Entry): Future[(App[_], Promise[Unit])] =
       main.initializedApp.get() match {
         case Some((app, promise)) => Future.successful((app, promise))
         case None                 => akka.pattern.after(100 millis)(checkUntilMainInitialized(main))
       }
 
-    val (app, promise) = checkUntilMainInitialized(backup.Main).futureValue
+    val (app, promise) = checkUntilMainInitialized(Main).futureValue
 
     promise.success(())
     app match {

--- a/cli-restore/src/test/scala/io/aiven/guardian/kafka/restore/CliSpec.scala
+++ b/cli-restore/src/test/scala/io/aiven/guardian/kafka/restore/CliSpec.scala
@@ -1,4 +1,4 @@
-package io.aiven.guardian.kafka
+package io.aiven.guardian.kafka.restore
 
 import io.aiven.guardian.kafka.configs.{KafkaCluster => KafkaClusterConfig}
 import io.aiven.guardian.kafka.restore.configs.{Restore => RestoreConfig}
@@ -46,12 +46,12 @@ class CliSpec extends AnyPropSpec with Matchers {
       "--single-message-per-kafka-request"
     )
 
-    try restore.Main.main(args.toArray)
+    try Main.main(args.toArray)
     catch {
       case _: Throwable =>
     }
-    restore.Main.initializedApp.get() match {
-      case Some(s3App: restore.S3App) =>
+    Main.initializedApp.get() match {
+      case Some(s3App: S3App) =>
         s3App.restoreConfig mustEqual RestoreConfig(Some(fromWhen),
                                                     Some(
                                                       Map(

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%highlight(%-5level)] %d{HH:mm:ss.SSS} %logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
# About this change - What it does

Moves the `CliSpec` to their respective packages

# Why this way

Due to currently both tests being in the same `io.aiven.guardian.kafka` but in different package's, if one of the tests fail then you don't know which one does.