### PR TITLE
Fix termination issue clispec

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -133,9 +133,9 @@ class Entry(val initializedApp: AtomicReference[Option[(App[_], Promise[Unit])]]
                   }
                 }
             }
-            val control = app.run()
-            val p       = Promise[Unit]()
+            val p = Promise[Unit]()
             initializedApp.set(Some((app, p)))
+            val control = app.run()
             Await.result(MainUtils.waitForShutdownSignal(p)(app.executionContext), Duration.Inf)
             Await.result(app.shutdown(control), 5 minutes)
         }

--- a/core/src/test/scala/io/aiven/guardian/kafka/Cancellable.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/Cancellable.scala
@@ -1,0 +1,39 @@
+package io.aiven.guardian.kafka
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Try
+
+import java.util.concurrent.FutureTask
+
+class Cancellable[T](executionContext: ExecutionContext, block: => T) {
+  private val promise = Promise[T]()
+
+  def future: Future[T] = promise.future
+
+  private val jf: FutureTask[T] = new FutureTask[T](() => block) {
+    override def done(): Unit = promise.complete(Try(get()))
+  }
+
+  def cancel(): Unit = jf.cancel(true)
+
+  executionContext.execute(jf)
+}
+
+object Cancellable {
+
+  /** Allows you to put a computation inside of a [[scala.concurrent.Future]] which can later be cancelled
+    * @param block
+    *   The computation to run inside of the [[scala.concurrent.Future]]
+    * @param executionContext
+    *   The [[scala.concurrent.ExecutionContext]] to run the [[scala.concurrent.Future]] on
+    * @return
+    *   A [[io.aiven.guardian.kafka.Cancellable]] providing both the [[scala.concurrent.Future]] and a `cancel` method
+    *   allowing you to terminate the [[scala.concurrent.Future]] at any time
+    * @see
+    *   Adapted from https://stackoverflow.com/a/39986418/1519631
+    */
+  def apply[T](block: => T)(implicit executionContext: ExecutionContext): Cancellable[T] =
+    new Cancellable[T](executionContext, block)
+}


### PR DESCRIPTION
# About this change - What it does

Solves the issue where `CliSpec` does not terminate if you don't provide the correct S3 credentials
Resolves: https://github.com/aiven/guardian-for-apache-kafka/issues/173

# Why this way

The main issue was resolved in the `Reorder when initializedApp is set so CliSpec terminates` commit, basically `initializedApp.set(Some((app, p)))` happens earlier which is what `CliSpec` polls on for the test.

`Make CliSpec computation cancellable` is a bonus which makes the `CliSpec` cancelled (normally `Future`'s cannot be cancelled).