### PR TITLE
Generalize kafka-topics cli help

### DIFF
--- a/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
+++ b/core-cli/src/main/scala/io/aiven/guardian/cli/options/Options.scala
@@ -19,7 +19,7 @@ trait Options {
     Opts.option[String]("s3-data-bucket", help = "S3 Bucket for storage of main backup data").orNone
 
   val topicsOpt: Opts[Option[NonEmptyList[String]]] =
-    Opts.options[String]("kafka-topics", help = "Kafka topics to backup").orNone
+    Opts.options[String]("kafka-topics", help = "Kafka topics to operate on").orNone
 
   val bootstrapServersOpt: Opts[Option[NonEmptyList[String]]] =
     Opts.options[String]("kafka-bootstrap-servers", help = "Kafka bootstrap servers").orNone


### PR DESCRIPTION
# About this change - What it does

Since `kafka-topics` is shared both by restore and backup the help parameter should be general and not mention backup 

# Why this way

Self explanatory
