### PR TITLE
Add logging/logback documentation

### DIFF
--- a/docs/src/main/paradox/application/design.md
+++ b/docs/src/main/paradox/application/design.md
@@ -1,0 +1,9 @@
+# Design
+
+Each application is contained within a corresponding sbt submodule, i.e. the application for `backup` is contained
+within the `cli-backup` sbt submodule. The `core-cli` sbt submodule contains common cli arguments (i.e. `kafka-topics`).
+
+Scala packaging has been disabled for these submodules which means that when publishing/packaging Guardian it won't push
+any built `.jar` files. This is because its unnecessary since you are meant to run these applications as a binary and
+not include it as a library. By the same token this also means that the cli modules are built with global inlining
+using `"-opt-inline-from:**"`, see [here](https://www.lightbend.com/blog/scala-inliner-optimizer) for more info.

--- a/docs/src/main/paradox/application/index.md
+++ b/docs/src/main/paradox/application/index.md
@@ -9,41 +9,12 @@ binaries provided are
 The CLI follows POSIX guidelines which means you can use `--help` as an argument to provide information on all of the
 parameters.
 
-## Package formats
+@@toc { depth=2 }
 
-Guardian is currently packaged using [sbt-native-packager](https://github.com/sbt/sbt-native-packager) to provide the
-following formats by using the sbt shell.
+@@@ index
 
-* `rpm`
-    * restore: `cliRestore/rpm:packageBin`. Created `rpm` file will be contained
-      in `cli-restore/target/rpm/RPMS/noarch/`
-    * backup: `cliBackup/rpm:packageBin`. Created `rpm` file will be contained in `cli-backup/target/rpm/RPMS/noarch/`
-      NOTE: In order to build packages you need to have the [rpm-tools](https://rpm.org/) (specifically `rpmbuild`)
-      installed and available on `PATH`. Please consult your Linux distribution for more info
-* `zip`
-    * restore: `cliRestore/universal:packageBin`. Created `zip` file will be contained
-      in `cli-restore/target/universal/`
-    * backup: `cliBackup/universal:packageBin`. Created `zip` file will be contained in `cli-backup/target/universal/`
-* `tar`
-    * restore: `cliRestore/universal:packageZipTarball`. Created `tar` file will be contained
-      in `cli-restore/target/universal/`
-    * backup: `cliBackup/universal:packageZipTarball`. Created `tar` file will be contained
-      in `cli-backup/target/universal/`
-* `Xz`
-    * restore: `cliRestore/universal:packageXzTarball`. Created `xz` file will be contained
-      in `cli-restore/target/universal/`
-    * backup: `cliBackup/universal:packageXzTarball`. Created `xz` file will be contained
-      in `cli-backup/target/universal/`
+* [design](design.md)
+* [packaging](packaging.md)
+* [logging](logging.md)
 
-Note that for these packages formats you need to have JRE installed on your system to run the package. For more details
-about packaging read the [docs](https://sbt-native-packager.readthedocs.io/en/latest/)
-
-## Design
-
-Each application is contained within a corresponding sbt submodule, i.e. the application for `backup` is contained
-within the `cli-backup` sbt submodule. The `core-cli` sbt submodule contains common cli arguments (i.e. `kafka-topics`).
-
-Scala packaging has been disabled for these submodules which means that when publishing/packaging Guardian it won't push
-any built `.jar` files. This is because its unnecessary since you are meant to run these applications as a binary and
-not include it as a library. By the same token this also means that the cli modules are built with global inlining
-using `"-opt-inline-from:**"`, see [here](https://www.lightbend.com/blog/scala-inliner-optimizer) for more info.
+@@@

--- a/docs/src/main/paradox/application/logging.md
+++ b/docs/src/main/paradox/application/logging.md
@@ -1,0 +1,9 @@
+# Logging
+
+The CLI provides its own default
+logback `logback.xml` [logging file](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core-cli/src/main/resources/logback.xml)
+which has sane defaults for typical usage. It's also possible to provide a custom `logback.xml` configuration file using
+the `--logback-file` command line argument.
+
+For more details about logback and/or the `logback.xml` configuration format read the
+@ref:[general architecture section on logging](../general-architecture/logging.md).

--- a/docs/src/main/paradox/application/packaging.md
+++ b/docs/src/main/paradox/application/packaging.md
@@ -1,0 +1,28 @@
+# Packaging
+
+Guardian is currently packaged using [sbt-native-packager](https://github.com/sbt/sbt-native-packager) to provide the
+following formats by using the sbt shell.
+
+* `rpm`
+    * restore: `cliRestore/rpm:packageBin`. Created `rpm` file will be contained
+      in `cli-restore/target/rpm/RPMS/noarch/`
+    * backup: `cliBackup/rpm:packageBin`. Created `rpm` file will be contained in `cli-backup/target/rpm/RPMS/noarch/`
+      NOTE: In order to build packages you need to have the [rpm-tools](https://rpm.org/) (specifically `rpmbuild`)
+      installed and available on `PATH`. Please consult your Linux distribution for more info
+* `zip`
+    * restore: `cliRestore/universal:packageBin`. Created `zip` file will be contained
+      in `cli-restore/target/universal/`
+    * backup: `cliBackup/universal:packageBin`. Created `zip` file will be contained in `cli-backup/target/universal/`
+* `tar`
+    * restore: `cliRestore/universal:packageZipTarball`. Created `tar` file will be contained
+      in `cli-restore/target/universal/`
+    * backup: `cliBackup/universal:packageZipTarball`. Created `tar` file will be contained
+      in `cli-backup/target/universal/`
+* `Xz`
+    * restore: `cliRestore/universal:packageXzTarball`. Created `xz` file will be contained
+      in `cli-restore/target/universal/`
+    * backup: `cliBackup/universal:packageXzTarball`. Created `xz` file will be contained
+      in `cli-backup/target/universal/`
+
+Note that for these packages formats you need to have JRE installed on your system to run the package. For more details
+about packaging read the [docs](https://sbt-native-packager.readthedocs.io/en/latest/)

--- a/docs/src/main/paradox/general-architecture/index.md
+++ b/docs/src/main/paradox/general-architecture/index.md
@@ -1,0 +1,11 @@
+# General Architecture
+
+General documentation about how Guardian for Apache Kafka is architected lives here.
+
+@@toc { depth=2 }
+
+@@@ index
+
+* [logging](logging.md)
+
+@@@

--- a/docs/src/main/paradox/general-architecture/logging.md
+++ b/docs/src/main/paradox/general-architecture/logging.md
@@ -1,0 +1,32 @@
+# Logging
+
+Guardian for Apache Kafka uses [logback](https://logback.qos.ch/index.html) to perform logging. This means if you are
+using the modules as libraries you need to provide a `logback.xml` in your classpath (typically this is done by putting
+the `logback.xml` in your `/src/main/resources` folder). Note that the Guardian modules do not provide a default
+`logback.xml` for deployed artifacts since this is typically the responsibility of an application to configure and
+provide.
+
+If you want examples of `logback.xml` configuration you can have a look at the
+official [logback page](https://logback.qos.ch/manual/configuration.html) but you can also the existing `logback.xml`
+use for the [cli](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core-cli/src/main/resources/logback.xml)
+or the
+[tests](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core/src/test/resources/logback.xml) as a
+reference.
+
+@@@ warning
+
+As documented at @extref:[akka logback configuration](akka:logging.html#logback-configuration) it is highly recommended
+to use an `AsyncAppender` in your configuration as this offsets the logging to a background thread otherwise you will
+end up blocking the core akka/akka-streams library whenever a log is made.
+
+@@@
+
+## Logback adapter for akka/akka-streams
+
+By default, akka/akka-streams uses its own asynchronous logger however they provide a
+@extref:[logging adapter](akka:logging.html#slf4j) which has already been preconfigured for use in Guardian.
+
+## CLI/Application
+
+Note that unlike the core libraries, the CLI application does provide a default `logback.xml`. For more details read
+@ref:[application logging](../application/logging.md).

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -13,6 +13,7 @@ to ensure that the tool runs reliably and as desired with large datasets in diff
 * [security](security.md)
 * [ci](ci.md)
 * [doc-generation](doc-generation.md)
+* [general-architecture](general-architecture/index.md)
 * [testing](testing/index.md)
 * [application](application/index.md)
 * [backup](backup/index.md)


### PR DESCRIPTION
# About this change - What it does

This PR adds information about logging in Guardian. It also separates out the `application` documentation into different sections. 

# Why this way

Self explanatory