### PR TITLE
Harden the GitHub Workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,11 +1,10 @@
 name: Scalafmt
 
+permissions: read-all
+
 on:
   pull_request:
     branches: ['**']
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -19,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check project is formatted
         uses: jrouly/scalafmt-native-action@v1


### PR DESCRIPTION
This patch improves security around GitHub Workflows:

For the `format.yml` workflow:

 * Set the default workflow permissions to `read` - because this workflow does not need to modify anything in the project.
 * Do not let `actions/checkout` persist (write to disk) the GitHub token - because this workflow does not need to modify anything in the project. And prevents other actions to look at the token.
 * Remove the `env:  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` section - this shares the token with every step. It is better to only do this on a per-step basis.

I am trying to understand the other two workflows. Both of those have the GITHUB_TOKEN and S3 tokens shared globally with all jobs, which doesn't feel right. This is simple to fix but I see a note on top of both `ci.yml` and `clean.yml` that those workflows are generated. There are some opportunities there to limit the risk of secret leaking, but it would mean I have to modify those files.

What do you think @mdedetrich ?