### PR TITLE
Only expose S3 secrets in sbt test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ on:
     branches: [main]
 
 env:
-  ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-  ALPAKKA_S3_REGION_DEFAULT_REGION: us-west-2
-  ALPAKKA_S3_AWS_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-  ALPAKKA_S3_AWS_CREDENTIALS_PROVIDER: static
-  ALPAKKA_S3_REGION_PROVIDER: static
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -62,6 +57,12 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Build project
+        env:
+          ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          ALPAKKA_S3_REGION_DEFAULT_REGION: us-west-2
+          ALPAKKA_S3_AWS_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          ALPAKKA_S3_AWS_CREDENTIALS_PROVIDER: static
+          ALPAKKA_S3_REGION_PROVIDER: static
         run: sbt ++${{ matrix.scala }} clean coverage test
 
       - name: Compile docs

--- a/build.sbt
+++ b/build.sbt
@@ -400,18 +400,20 @@ ThisBuild / semanticdbEnabled := true
 // See https://scalacenter.github.io/scalafix/docs/users/installation.html#sbt
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
-ThisBuild / githubWorkflowEnv ++= Map(
-  "ALPAKKA_S3_REGION_PROVIDER"                   -> "static",
-  "ALPAKKA_S3_REGION_DEFAULT_REGION"             -> "us-west-2",
-  "ALPAKKA_S3_AWS_CREDENTIALS_PROVIDER"          -> "static",
-  "ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID"     -> "${{ secrets.AWS_ACCESS_KEY }}",
-  "ALPAKKA_S3_AWS_CREDENTIALS_SECRET_ACCESS_KEY" -> "${{ secrets.AWS_SECRET_KEY }}"
-)
-
 ThisBuild / githubWorkflowJavaVersions := List(JavaSpec.temurin("11"))
 
 ThisBuild / githubWorkflowBuild := Seq(
-  WorkflowStep.Sbt(List("clean", "coverage", "test"), name = Some("Build project")),
+  WorkflowStep.Sbt(
+    List("clean", "coverage", "test"),
+    name = Some("Build project"),
+    env = Map(
+      "ALPAKKA_S3_REGION_PROVIDER"                   -> "static",
+      "ALPAKKA_S3_REGION_DEFAULT_REGION"             -> "us-west-2",
+      "ALPAKKA_S3_AWS_CREDENTIALS_PROVIDER"          -> "static",
+      "ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID"     -> "${{ secrets.AWS_ACCESS_KEY }}",
+      "ALPAKKA_S3_AWS_CREDENTIALS_SECRET_ACCESS_KEY" -> "${{ secrets.AWS_SECRET_KEY }}"
+    )
+  ),
   WorkflowStep.Sbt(List("docs/makeSite"), name = Some("Compile docs"))
 )
 


### PR DESCRIPTION
# About this change - What it does

Only expose S3 secrets when we run tests rather than the entire pipeline

# Why this way

Implements the solution suggested at https://github.com/aiven/guardian-for-apache-kafka/pull/186#issuecomment-1089450741.
