### PR TITLE
Use S3 OIDC credentials provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,16 +45,20 @@ jobs:
       - name: 'Linter: Scalafix checks'
         run: sbt '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: 'arn:aws:iam::310017459104:role/aiven-guardian-github-action'
+          aws-region: us-west-2
+          role-duration-seconds: 3600
+
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Build project
         env:
-          PEKKO_CONNECTORS_S3_AWS_CREDENTIALS_PROVIDER: static
-          PEKKO_CONNECTORS_S3_REGION_DEFAULT_REGION: us-west-2
-          PEKKO_CONNECTORS_S3_AWS_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          PEKKO_CONNECTORS_S3_AWS_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          PEKKO_CONNECTORS_S3_REGION_PROVIDER: static
+          PEKKO_CONNECTORS_S3_REGION_PROVIDER: default
+          PEKKO_CONNECTORS_S3_AWS_CREDENTIALS_PROVIDER: default
         run: sbt '++ ${{ matrix.scala }}' clean coverage test
 
       - name: Compile docs

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientSpec.scala
@@ -32,7 +32,7 @@ trait BackupClientSpec extends S3Spec with Matchers with BeforeAndAfterAll with 
   val ThrottleElements: Int          = 100
   val ThrottleAmount: FiniteDuration = 1 millis
 
-  property("backup method completes flow correctly for all valid Kafka events", RealS3Available) {
+  property("backup method completes flow correctly for all valid Kafka events") {
     forAll(kafkaDataWithTimePeriodsGen(), s3ConfigGen(useVirtualDotHost, bucketPrefix)) {
       (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
         logger.info(s"Data bucket is ${s3Config.dataBucket}")

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
@@ -43,8 +43,7 @@ class MockedKafkaClientBackupConsumerSpec
   override lazy val enableCleanup: Option[FiniteDuration] = Some(5 seconds)
 
   property(
-    "Creating many objects in a small period of time works despite S3's in progress multipart upload eventual consistency issues",
-    RealS3Available
+    "Creating many objects in a small period of time works despite S3's in progress multipart upload eventual consistency issues"
   ) {
     forAll(
       kafkaDataWithTimePeriodsGen(20,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
@@ -96,7 +96,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }).runWith(Sink.seq)
   }
 
-  property("basic flow without interruptions using PeriodFromFirst works correctly", RealS3Available) {
+  property("basic flow without interruptions using PeriodFromFirst works correctly") {
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -173,7 +173,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("suspend/resume using PeriodFromFirst creates separate object after resume point", RealS3Available) {
+  property("suspend/resume using PeriodFromFirst creates separate object after resume point") {
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -292,7 +292,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property("suspend/resume for same object using ChronoUnitSlice works correctly", RealS3Available) {
+  property("suspend/resume for same object using ChronoUnitSlice works correctly") {
     forAll(kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -387,10 +387,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property(
-    "Backup works with multiple keys",
-    RealS3Available
-  ) {
+  property("Backup works with multiple keys") {
     forAll(kafkaDataWithTimePeriodsGen(min = 30000, max = 30000),
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
@@ -470,10 +467,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property(
-    "Concurrent backups using real Kafka cluster with a single key",
-    RealS3Available
-  ) {
+  property("Concurrent backups using real Kafka cluster with a single key") {
     forAll(
       kafkaDataWithMinByteSizeGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),
@@ -595,10 +589,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
     }
   }
 
-  property(
-    "Concurrent backups using real Kafka cluster with a multiple keys",
-    RealS3Available
-  ) {
+  property("Concurrent backups using real Kafka cluster with a multiple keys") {
     forAll(
       kafkaDataWithTimePeriodsGen(min = 30000, max = 30000),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -2,15 +2,12 @@ package io.aiven.guardian.kafka.s3
 
 import com.softwaremill.diffx.ShowConfig
 import com.typesafe.scalalogging.LazyLogging
-import io.aiven.guardian.kafka.TestUtils
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import io.aiven.guardian.pekko.PekkoHttpTestKit
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.pekko
 import org.scalactic.Prettifier
 import org.scalactic.SizeLimit
-import org.scalatest.Ignore
-import org.scalatest.Tag
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.propspec.AnyPropSpecLike
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -45,12 +42,6 @@ trait S3Spec
     with ScalaFutures
     with Config
     with LazyLogging {
-
-  // See https://stackoverflow.com/a/38834773
-  case object RealS3Available
-      extends Tag(
-        if (TestUtils.checkEnvVarAvailable("ALPAKKA_S3_AWS_CREDENTIALS_ACCESS_KEY_ID")) "" else classOf[Ignore].getName
-      )
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(20 minutes, 100 millis)

--- a/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/TestUtils.scala
@@ -98,15 +98,4 @@ object TestUtils {
     recurseUntilHitTimeUnit(previousEnum, buffer)
   }
 
-  def checkEnvVarAvailable(env: String): Boolean =
-    try
-      sys.env.get(env) match {
-        case Some(value) if value.isBlank => false
-        case Some(_)                      => true
-        case None                         => false
-      }
-    catch {
-      case _: NoSuchElementException => false
-    }
-
 }

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
@@ -63,7 +63,7 @@ trait RealS3RestoreClientTest
   override lazy val bucketPrefix: Option[String]          = Some("guardian-")
   override lazy val enableCleanup: Option[FiniteDuration] = Some(5 seconds)
 
-  property("Round-trip with backup and restore", RealS3Available) {
+  property("Round-trip with backup and restore") {
     forAll(
       kafkaDataWithMinSizeRenamedTopicsGen(S3.MinChunkSize, 2, reducedConsumerRecordsToJson),
       s3ConfigGen(useVirtualDotHost, bucketPrefix),


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Uses AWS OIDC provider for credentials rather than raw key/secret

# Why this way

Using github's secrets has the issue where if someone creates a pull request that it outside of the Aiven org (which ultimately means creating a fork) then github-actions will not expose the secrets for security reasons.

The proper way to solve this problem is to use the OIDC provider https://github.com/aws-actions/configure-aws-credentials which afaik creates the same key/secret in environment variables however those specific key/secret that is generated is temporary so even if a bad actor gets access to them they would have already been expired.

With the latest version of sbt-github-actions merged (see https://github.com/aiven/guardian-for-apache-kafka/pull/410) its now possible to do this. 