### PR TITLE
Log exceptions thrown inside SubFlow

### DIFF
--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -429,7 +429,7 @@ trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
 
             // TODO This is temporary until https://github.com/aiven/guardian-for-apache-kafka/issues/221 is resolved.
             // Since SubFlow currently doesn't respect supervision strategy any exceptions thrown are just suppressed
-            // and causes the stream to loop indefinitely so lets at least log the exception so users know whats going
+            // and causes the stream to loop indefinitely so lets at least log the exception so users know what's going
             // on
             f.onComplete {
               case Failure(e) =>


### PR DESCRIPTION
# About this change - What it does

Due to an existing limitation with `SubFlow` (details in comments in PR), any exceptions that get thrown in the `SubFlow` are suppressed and cause the stream to retry and hence loop indefinitely.

References: https://github.com/aiven/guardian-for-apache-kafka/issues/221

# Why this way

The core problem is not solvable right now (at least without upstream changes) however we can at least log the exception so users know whats going on. This is particularly problematic for silly mistakes such as getting S3 credentials wrong as currently there is no feedback at all.
