### PR TITLE
Disable concurrent executions and enable draining control

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -30,8 +30,6 @@ trait App[T <: KafkaClientInterface] extends LazyLogging {
 
   def shutdown(control: Consumer.Control): Future[Done] = {
     logger.info("Shutdown of Guardian detected")
-    // Ideally we should be using drainAndShutdown however this isn't possible due to
-    // https://github.com/aiven/guardian-for-apache-kafka/issues/80
-    control.stop().flatMap(_ => control.shutdown())
+    control.shutdown()
   }
 }

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -359,7 +359,7 @@ trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
     *   The `KafkaClientInterface.Control` which depends on the implementation of `T` (typically this is used to control
     *   the underlying stream).
     */
-  def backup: RunnableGraph[kafkaClientInterface.Control] = {
+  def backup: RunnableGraph[kafkaClientInterface.MatCombineResult] = {
     val withBackupStreamPositions = calculateBackupStreamPositions(sourceWithPeriods(sourceWithFirstRecord))
 
     val split = withBackupStreamPositions
@@ -445,7 +445,7 @@ trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
       )
       .mergeSubstreamsWithParallelism(1)
 
-    subFlowSink.toMat(Sink.ignore)(Keep.left)
+    subFlowSink.toMat(Sink.ignore)(kafkaClientInterface.matCombine)
   }
 }
 

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -409,41 +409,43 @@ trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
       }
 
     @nowarn("msg=method lazyInit in object Sink is deprecated")
-    val subFlowSink = substreams.to(
-      // See https://stackoverflow.com/questions/68774425/combine-prefixandtail1-with-sink-lazysink-for-subflow-created-by-splitafter/68776660?noredirect=1#comment121558518_68776660
-      Sink.lazyInit(
-        {
-          case (_, start: Start) =>
-            implicit val ec: ExecutionContext = system.dispatcher
-            logger.debug(s"Calling getCurrentUploadState with key:${start.key}")
-            val f = for {
-              uploadStateResult <- getCurrentUploadState(start.key)
-              _ = logger.debug(s"Received $uploadStateResult from getCurrentUploadState with key:${start.key}")
-              _ <- (uploadStateResult.previous, uploadStateResult.current) match {
-                     case (Some(previous), None) =>
-                       terminateSource.runWith(backupToStorageTerminateSink(previous)).map(Some.apply)
-                     case _ => Future.successful(None)
-                   }
-            } yield prepareStartOfStream(uploadStateResult, start)
+    val subFlowSink = substreams
+      .alsoTo(
+        // See https://stackoverflow.com/questions/68774425/combine-prefixandtail1-with-sink-lazysink-for-subflow-created-by-splitafter/68776660?noredirect=1#comment121558518_68776660
+        Sink.lazyInit(
+          {
+            case (_, start: Start) =>
+              implicit val ec: ExecutionContext = system.dispatcher
+              logger.debug(s"Calling getCurrentUploadState with key:${start.key}")
+              val f = for {
+                uploadStateResult <- getCurrentUploadState(start.key)
+                _ = logger.debug(s"Received $uploadStateResult from getCurrentUploadState with key:${start.key}")
+                _ <- (uploadStateResult.previous, uploadStateResult.current) match {
+                       case (Some(previous), None) =>
+                         terminateSource.runWith(backupToStorageTerminateSink(previous)).map(Some.apply)
+                       case _ => Future.successful(None)
+                     }
+              } yield prepareStartOfStream(uploadStateResult, start)
 
-            // TODO This is temporary until https://github.com/aiven/guardian-for-apache-kafka/issues/221 is resolved.
-            // Since SubFlow currently ignores any given supervision strategy we have to use a
-            // SubstreamCancelStrategy.propagate however the exception message is still hence why we need to manually
-            // log it.
-            f.onComplete {
-              case Failure(e) =>
-                logger.error("Unhandled exception in stream", e)
-              case Success(_) =>
-            }
+              // TODO This is temporary until https://github.com/aiven/guardian-for-apache-kafka/issues/221 is resolved.
+              // Since SubFlow currently ignores any given supervision strategy we have to use a
+              // SubstreamCancelStrategy.propagate however the exception message is still hence why we need to manually
+              // log it.
+              f.onComplete {
+                case Failure(e) =>
+                  logger.error("Unhandled exception in stream", e)
+                case Success(_) =>
+              }
 
-            f
-          case _ => throw Errors.ExpectedStartOfSource
-        },
-        empty
+              f
+            case _ => throw Errors.ExpectedStartOfSource
+          },
+          empty
+        )
       )
-    )
+      .mergeSubstreamsWithParallelism(1)
 
-    subFlowSink
+    subFlowSink.toMat(Sink.ignore)(Keep.left)
   }
 }
 

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClient.scala
@@ -52,6 +52,7 @@ class KafkaClient(
     with LazyLogging {
   override type CursorContext        = CommittableOffset
   override type Control              = Consumer.Control
+  override type MatCombineResult     = Consumer.DrainingControl[Done]
   override type BatchedCursorContext = CommittableOffsetBatch
 
   import KafkaClient._
@@ -101,6 +102,13 @@ class KafkaClient(
     *   A `Sink` that allows you to commit a `CursorContext` to Kafka to signify you have processed a message
     */
   override def commitCursor: Sink[CommittableOffsetBatch, Future[Done]] = Committer.sink(committerSettings)
+
+  /** @return
+    *   The result of this function gets directly passed into the `combine` parameter of
+    *   [[akka.stream.scaladsl.Source.toMat]]
+    */
+  override def matCombine: (Consumer.Control, Future[Done]) => Consumer.DrainingControl[Done] =
+    Consumer.DrainingControl[Done].apply
 
   /** How to batch an immutable iterable of `CursorContext` into a `BatchedCursorContext`
     * @param cursors

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaClientInterface.scala
@@ -19,6 +19,11 @@ trait KafkaClientInterface {
     */
   type Control
 
+  /** The type that represents the result of the `combine` parameter that is supplied to
+    * [[akka.stream.scaladsl.Source.toMat]]
+    */
+  type MatCombineResult
+
   /** The type that represents the result of batching a `CursorContext`
     */
   type BatchedCursorContext
@@ -32,6 +37,12 @@ trait KafkaClientInterface {
     *   A `Sink` that allows you to commit a `CursorContext` to Kafka to signify you have processed a message
     */
   def commitCursor: Sink[BatchedCursorContext, Future[Done]]
+
+  /** @return
+    *   The result of this function gets directly passed into the `combine` parameter of
+    *   [[akka.stream.scaladsl.Source.toMat]]
+    */
+  def matCombine: (Control, Future[Done]) => MatCombineResult
 
   /** How to batch an immutable iterable of `CursorContext` into a `BatchedCursorContext`
     * @param cursors

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
@@ -2,9 +2,7 @@ package io.aiven.guardian.kafka.backup
 
 import akka.Done
 import akka.NotUsed
-import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.SourceWithContext
+import akka.stream.scaladsl._
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 
 import scala.collection.immutable
@@ -34,6 +32,11 @@ class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUse
     */
   override type Control = Future[NotUsed]
 
+  /** The type that represents the result of the `combine` parameter that is supplied to
+    * [[akka.stream.scaladsl.Source.toMat]]
+    */
+  override type MatCombineResult = Future[NotUsed]
+
   /** The type that represents the result of batching a `CursorContext`
     */
   override type BatchedCursorContext = Long
@@ -47,6 +50,12 @@ class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUse
         (reducedConsumerRecord, reducedConsumerRecord.offset)
       })
       .mapMaterializedValue(Future.successful)
+
+  /** @return
+    *   The result of this function gets directly passed into the `combine` parameter of
+    *   [[akka.stream.scaladsl.Source.toMat]]
+    */
+  override def matCombine: (Future[NotUsed], Future[Done]) => Future[NotUsed] = Keep.left
 
   /** @return
     *   A `Sink` that allows you to commit a `CursorContext` to Kafka to signify you have processed a message


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This PR does 2 changes, each change being represented by its own commit. The first change makes sure that the SubFlow's don't occur concurrently and due to this change we can also solve the issue of not having a proper drain control (see https://doc.akka.io/docs/alpakka-kafka/current/consumer.html) with these changes being done in the second commit.

References: #178 
Resolves: #80 

# Why this way

So it turns out that as documented in https://doc.akka.io/docs/akka/current/stream/stream-substream.html#splitwhen-and-splitafter its possible to have multiple sub flow's occurring at the same time. Initially I thought this would be a non issue since the kafka records we get are ordered  over time with a timestamp so it wasn't possible to parallelize anyways however it turns out if you are getting a lot of records very quickly you can still get multiple executions at the same time which describes the issue at #178, i.e.
```
[DEBUG] 14:38:36.240 BackupClient - Calling getCurrentUploadState with key:2022-02-02T20:47:00Z.json
[DEBUG] 14:38:36.262 BackupClient - Calling getCurrentUploadState with key:2022-02-02T20:48:00Z.json
[DEBUG] 14:38:36.271 BackupClient - Calling getCurrentUploadState with key:2022-02-02T20:49:00Z.json
[INFO ] 14:38:36.756 BackupClient - 2022-02-02T20:48:00Z.json current exists:false
[INFO ] 14:38:36.756 BackupClient - 2022-02-02T20:47:00Z.json current exists:false
[INFO ] 14:38:36.758 BackupClient - Incomplete uploads for key: 2022-02-02T20:48:00Z.json is empty
[DEBUG] 14:38:36.761 BackupClient - Received UploadStateResult(None,None,false) from getCurrentUploadState with key:2022-02-02T20:48:00Z.json
[INFO ] 14:38:36.761 BackupClient - Creating new upload with bucket: guardian-presentation and key: 2022-02-02T20:48:00Z.json
[INFO ] 14:38:36.775 BackupClient - 2022-02-02T20:49:00Z.json current exists:false
[INFO ] 14:38:36.775 BackupClient - Incomplete uploads for key: 2022-02-02T20:49:00Z.json is empty
[DEBUG] 14:38:36.775 BackupClient - Received UploadStateResult(None,None,false) from getCurrentUploadState with key:2022-02-02T20:49:00Z.json
[INFO ] 14:38:36.775 BackupClient - Creating new upload with bucket: guardian-presentation and key: 2022-02-02T20:49:00Z.json
[INFO ] 14:38:36.780 BackupClient - Incomplete uploads for key: 2022-02-02T20:47:00Z.json is empty
[DEBUG] 14:38:36.780 BackupClient - Received UploadStateResult(None,None,false) from getCurrentUploadState with key:2022-02-02T20:47:00Z.json
```

As you can see there are 3 cases of `Calling getCurrentUploadState` before the `Received UploadStateResult` which means they are happening at the same time. Using `mergeSubstreamsWithParallelism(1)` enforces that we can only have a single instance of each time time slice occurring at a single time.

This is actually quite critical because of 2 reasons

* The tracking of the Kafka cursors that get committed is a global singleton so you can't have concurrent updates modifying the latest cursor position otherwise you can get into problems where you commit a newer kafka cursor where  as work with an older kafka cursor hasn't even completed yet (which would be a problem if that older kafka work fails).
* This can be an explanation/factor in the current ongoing issues with weird eventually consistent/concurrent calls into S3

Additionally the usage of `mergeSubstreamsWithParallelism(1)` changes the type of `SubFlow` to just a normal `Flow` which means we now have the ability to use a `DrainingControl` which is the recommended and safe way to gracefully terminate the Kafka Stream (what we had beforehand was just a workaround). The usage of the `DrainingControl` might also help solving the current ongoing problems.
