### PR TITLE
Fix stream leak by using appropriate function

### DIFF
--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -45,9 +45,7 @@ class BackupClient[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings
   override type State = CurrentS3State
 
   private[backup] def checkObjectExists(key: String)(implicit executionContext: ExecutionContext): Future[Boolean] = {
-    // Note that S3.download doesn't immediately download the file, it first checks if it exists and returns a
-    // not yet started `Source`if it does exist (in other words we aren't unnecessarily downloading the file)
-    val base = S3.download(s3Config.dataBucket, key)
+    val base = S3.getObjectMetadata(s3Config.dataBucket, key)
 
     for {
       result <- maybeS3Settings


### PR DESCRIPTION
# About this change - What it does

This PR fixes the memory leak that was discovered in https://github.com/aiven/guardian-for-apache-kafka/pull/232

# Why this way

Turns out there is an already existing function in S3 Alpakka's client called `S3.getObjectMetadata` which is also meant to be used for checking for the existence of an obejct.
