### PR TITLE
Use ExecutionContext.parasitic on non-blocking map operations

### DIFF
--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -422,7 +422,9 @@ trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
                 _ = logger.debug(s"Received $uploadStateResult from getCurrentUploadState with key:${start.key}")
                 _ <- (uploadStateResult.previous, uploadStateResult.current) match {
                        case (Some(previous), None) =>
-                         terminateSource.runWith(backupToStorageTerminateSink(previous)).map(Some.apply)
+                         terminateSource
+                           .runWith(backupToStorageTerminateSink(previous))
+                           .map(Some.apply)(ExecutionContext.parasitic)
                        case _ => Future.successful(None)
                      }
               } yield prepareStartOfStream(uploadStateResult, start)


### PR DESCRIPTION
# About this change - What it does

Explicitly use `ExecutionContext.parasitic` when doing non-block `.map` operations on a `Future`.

# Why this way

Non blocking CPU operations done inside of a `.map` on a `Future` should explicitly use `ExecutionContext.parasitic` as to not overload the default `ExecutionContext` (which is typically a `ForkJoinPool` or some variant).

Note that `ExecutionContext.parasitic` executes the task immediately on the current thread so its designed to be used for "cheap" operations (such as boxing data structures or using constructors).
