### PR TITLE
Remove redundant implicit ExecutionContext

### DIFF
--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -36,7 +36,7 @@ class BackupClient[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings
 
   override type State = CurrentS3State
 
-  private[backup] def checkObjectExists(key: String)(implicit executionContext: ExecutionContext): Future[Boolean] = {
+  private[backup] def checkObjectExists(key: String): Future[Boolean] = {
     val base = S3.getObjectMetadata(s3Config.dataBucket, key)
 
     maybeS3Settings


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Ever since the last change to use explicit `ExecutionContext.parasitic`, the `(implicit executionContext: ExecutionContext)` is no longer neccessary.
