### PR TITLE
Update paradox and use github directive

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -340,8 +340,10 @@ lazy val docs = project
       "extref.alpakka-docs.base_url"     -> s"https://docs.akka.io/docs/alpakka/${binaryVersion(alpakkaVersion)}/%s",
       "extref.alpakka-kafka-docs.base_url" -> s"https://docs.akka.io/docs/alpakka-kafka/${binaryVersion(alpakkaVersion)}/%s",
       "extref.kafka-docs.base_url" -> s"https://kafka.apache.org/${binaryVersion(kafkaClientsVersion).replace(".", "")}/%s",
-      "extref.pureconfig.base_url"          -> s"https://pureconfig.github.io/docs/",
-      "extref.scalatest.base_url"           -> s"https://www.scalatest.org/scaladoc/$scalaTestVersion/org/scalatest/%s",
+      "extref.pureconfig.base_url" -> s"https://pureconfig.github.io/docs/",
+      "extref.scalatest.base_url"  -> s"https://www.scalatest.org/scaladoc/$scalaTestVersion/org/scalatest/%s",
+      "github.base_url" -> s"https://github.com/aiven/guardian-for-apache-kafka/tree/${if (isSnapshot.value) "main"
+        else "v" + version.value}",
       "scaladoc.io.aiven.guardian.base_url" -> s"/guardian-for-apache-kafka/${(Preprocess / siteSubdirName).value}/"
     )
   )

--- a/docs/src/main/paradox/application/logging.md
+++ b/docs/src/main/paradox/application/logging.md
@@ -1,9 +1,9 @@
 # Logging
 
 The CLI provides its own default
-logback `logback.xml` [logging file](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core-cli/src/main/resources/logback.xml)
-which has sane defaults for typical usage. It's also possible to provide a custom `logback.xml` configuration file using
-the `--logback-file` command line argument.
+logback `logback.xml` @github[logging file](/core-cli/src/main/resources/logback.xml) which has sane defaults for
+typical usage. It's also possible to provide a custom `logback.xml` configuration file using the `--logback-file`
+command line argument.
 
 For more details about logback and/or the `logback.xml` configuration format read the
 @ref:[general architecture section on logging](../general-architecture/logging.md).

--- a/docs/src/main/paradox/ci.md
+++ b/docs/src/main/paradox/ci.md
@@ -7,14 +7,14 @@ performed using [sbt-github-actions][sbt-github-actions-link].
 ## Design
 
 One thing to note about [sbt-github-actions][sbt-github-actions-link] is that it generates the github workflow files
-directly from the sbt [build definition file](https://github.com/aiven/guardian-for-apache-kafka/blob/main/build.sbt).
+directly from the sbt @github[build definition file](/build.sbt).
 This means that the `build.sbt` is the source of truth and hence [sbt-github-actions][sbt-github-actions-link] also
 checks that the github workflow is in sync with `build.sbt` as part of the CI process.
 
 Essentially that means any changes to `build.sbt` (such as updating Scala versions) can also cause changes in github
 workflow actions. Likewise if you need to do any custom changes to
-the [ci.yaml](https://github.com/aiven/guardian-for-apache-kafka/blob/main/.github/workflows/ci.yml) you need to do this
-in `build.sbt` using [sbt-github-actions][sbt-github-actions-link] SBT dsl.
+the @github[ci.yaml](/.github/workflows/ci.yml) file you need to do this in `build.sbt` using
+[sbt-github-actions][sbt-github-actions-link] SBT dsl.
 
 To regenerate the relevant github workflow files after changes to `build.sbt` are done you need to run
 
@@ -27,17 +27,14 @@ In the sbt shell. For more information go [here](https://github.com/djspiewak/sb
 ## Scalafmt
 
 In addition and separately to [sbt-github-actions][sbt-github-actions-link] Guardian also has
-a [scalafmt][scalafmt-link]
-pipeline that checks the code is correctly formatted on each PR. This allows
-the [scalafmt pipeline](https://github.com/aiven/guardian-for-apache-kafka/blob/main/.github/workflows/format.yml) to
-run at the same time the main build does. Furthermore, it
-uses [scalafmt-native](https://scalameta.org/scalafmt/docs/installation.html#native-image) for improved runtime
-performance (typically it takes 5-10 seconds to check the entire project is formatted)
+a [scalafmt][scalafmt-link] pipeline that checks the code is correctly formatted on each PR. This allows the
+@github[scalafmt pipeline](/.github/workflows/format.yml) to run at the same time the main build 
+does. Furthermore, it uses [scalafmt-native](https://scalameta.org/scalafmt/docs/installation.html#native-image) for
+improved runtime performance (typically it takes 5-10 seconds to check the entire project is formatted).
 
 This means that if you ever update the scalafmt version in
-the [configuration file](https://github.com/aiven/guardian-for-apache-kafka/blob/main/.scalafmt.conf#L1) you also need
-to update it in
-the [scalafmt-pipeline](https://github.com/aiven/guardian-for-apache-kafka/blob/main/.github/workflows/format.yml#L26).
+the @github[configuration file](/.scalafmt.conf#L1) you also need to update it in the
+@github[scalafmt-pipeline](/.github/workflows/format.yml#L26).
 
 [sbt-github-actions-link]: https://github.com/djspiewak/sbt-github-actions
 [scalafmt-link]: https://scalameta.org/scalafmt/

--- a/docs/src/main/paradox/doc-generation.md
+++ b/docs/src/main/paradox/doc-generation.md
@@ -17,14 +17,13 @@ using [github pages][github-pages-link]. In addition various other plugins are u
 ## Design
 
 [sbt-paradox][sbt-paradox-link] generates documentation using standard [Markdown](https://www.markdownguide.org/). The
-documentation can be found in the [docs-folder](https://github.com/aiven/guardian-for-apache-kafka/tree/main/docs). Note
-that this folder also corresponds to a sbt-module which is also named `docs` which also means that commands related to
-documentation are run in that sbt sub-project (i.e. `docs/makeSite` generates the documentation site).
+documentation can be found in the @github[docs-folder](/docs). Note that this folder also corresponds to a sbt-module
+which is also named `docs` which also means that commands related to documentation are run in that sbt sub-project
+(i.e. `docs/makeSite` generates the documentation site).
 
 Guardian also uses [scaladoc][scaladoc-link] which is already included within Scala compiler/SBT to generate Scala API
-documentation.
-[scaladoc][scaladoc-link] is analogous to Java's own [javadoc](https://en.wikipedia.org/wiki/Javadoc) which generates
-API documentation that is written within the code itself.
+documentation. [scaladoc][scaladoc-link] is analogous to Java's own [javadoc](https://en.wikipedia.org/wiki/Javadoc)
+which generates API documentation that is written within the code itself.
 
 One advantage of using [sbt-paradox][sbt-paradox-link] and its various plugins as the main driver for documentation
 generation is it that checks at document generation (i.e. compile time) that the docs are well-formed. This checking

--- a/docs/src/main/paradox/general-architecture/logging.md
+++ b/docs/src/main/paradox/general-architecture/logging.md
@@ -8,10 +8,8 @@ provide.
 
 If you want examples of `logback.xml` configuration you can have a look at the
 official [logback page](https://logback.qos.ch/manual/configuration.html) but you can also use existing `logback.xml`'s
-from either the [cli](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core-cli/src/main/resources/logback.xml)
-or the
-[tests](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core/src/test/resources/logback.xml) as a
-reference.
+from either the @github[cli](/core-cli/src/main/resources/logback.xml) or the
+@github[tests](/core/src/test/resources/logback.xml) as a reference.
 
 @@@ warning
 

--- a/docs/src/main/paradox/security.md
+++ b/docs/src/main/paradox/security.md
@@ -15,15 +15,13 @@ You can use the sbt shell to generate a report at any time using
 dependencyCheckAggregate
 ```
 
-This will overwrite the [current report file][dependency-check-report-link]
+This will overwrite the @github[current report file](/dependency-check/dependency-check-report.html)
 
 ### Suppressing false positives
 
 Sometimes it is possible that a false positive get generated in the report. To add a false positive, first you need to
-open the [report file][dependency-check-report-link] in a supported browser. In the list of found vulnerabilities there
+open the @github[report file](/dependency-check/dependency-check-report.html) in a supported browser. In the list of found vulnerabilities there
 should be a suppress button which when clicked displays a popup containing an `XML` suppression entry. You then add
 that `<suppress>` tag entry to the
 existing [suppression-file](https://github.com/aiven/guardian-for-apache-kafka/edit/main/dependency-check/suppression.xml)
 . Finally, regenerate the report again using sbt's `dependencyCheckAggregate`
-
-[dependency-check-report-link]: https://github.com/aiven/guardian-for-apache-kafka/blob/main/dependency-check/dependency-check-report.html

--- a/docs/src/main/paradox/testing/s3.md
+++ b/docs/src/main/paradox/testing/s3.md
@@ -15,5 +15,4 @@ export ALPAKKA_S3_REGION_DEFAULT_REGION=eu-central-1
 
 Due to a current limitation where there is no way to expose Github secrets to PR's made from external forks, tests which
 run against S3 need to be @extref:[Tagged](scalatest:Tag.html)
-using [RealS3Available](https://github.com/aiven/guardian-for-apache-kafka/blob/main/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala#L45-L48)
-.
+using @github[RealS3Available](/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala#L45-L48).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"             % "2.4.6")
-addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"              % "0.9.2")
+addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox"              % "0.10.2")
 addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-apidoc"       % "0.10+12-1d5b87db")
 addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-project-info" % "2.0.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"               % "0.5.0")


### PR DESCRIPTION
# About this change - What it does

Updates paradox dependency while also implementing the `@github` [directive](https://developer.lightbend.com/docs/paradox/current/directives/linking.html#github-directive) for github references. 

Resolves: #187 

# Why this way

Read the referenced issue to get more details about why its done this way. The new version of paradox fixes the bug referenced in the issue so we are now able to use the github directive. Actual markdown changes are quite self explanatory.
