### PR TITLE
Update scoverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ val scalaCheckOpsVersion       = "2.8.1"
 val enumeratumVersion          = "1.7.0"
 val organizeImportsVersion     = "0.6.0"
 
+// See https://github.com/akka/akka-http/pull/3995 and https://github.com/akka/akka-http/pull/3995#issuecomment-1026978593
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
+
 val flagsFor12 = Seq(
   "-Xlint:_",
   "-Ywarn-infer-any",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.codecommit"                    % "sbt-github-actions"       % 
 addSbtPlugin("com.github.sbt"                    % "sbt-pgp"                  % "2.1.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-release"              % "1.1.0")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"             % "0.10.1")
-addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "1.9.3")
+addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.0")
 addSbtPlugin("org.scoverage"                     % "sbt-coveralls"            % "1.3.2")
 addSbtPlugin("net.vonbuchholtz"                  % "sbt-dependency-check"     % "4.1.0")
 


### PR DESCRIPTION
# About this change - What it does
This PR updates scoverage

# Why this way

Due to a dependency resolution incompatibility, i.e.

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang.modules:scala-xml_2.13:2.1.0 (early-semver) is selected over 1.3.0
[error] 	    +- org.scoverage:scalac-scoverage-reporter_2.13:2.0.0 (depends on 2.1.0)
[error] 	    +- com.typesafe.akka:akka-http-xml_2.13:10.2.9        (depends on 1.3.0)
```

A manual version override needed to be specified (see https://github.com/akka/akka-http/pull/3995#issuecomment-1102533469). Do note that 2.1.0 is bin compatible with 1.3.0, main reason for 2.1.0 release is Scala3/depreciation of some really old API's.