### PR TITLE
Randomly generate Kafka Consumer Group's in tests

### DIFF
--- a/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
+++ b/core/src/test/scala/io/aiven/guardian/kafka/Generators.scala
@@ -258,4 +258,12 @@ object Generators {
                    .map(_.mkString)
              }
   } yield topic
+
+  /** Generator for a valid Kafka consumer group that can be used in actual Kafka clusters
+    */
+  lazy val kafkaConsumerGroupGen: Gen[String] = for {
+    size    <- Gen.choose(1, 50)
+    groupId <- Gen.listOfN(size, Gen.alphaChar)
+  } yield groupId.mkString
+
 }


### PR DESCRIPTION
# About this change - What it does
Rather than using a constant Kafka consumer group, randomly generate them using scalacheck

# Why this way

This PR is a theoretical attempt to both help solve flaky tests as well as improve the performance of tests (I have a suspicion that reusing the same constant consumer group amongst a lot of tests against a real kafka cluster is causing the tests to runs slower). Finally this will be useful in the future when parallelising tests.

Note that the large diff is due to scalafmt, you can hide whitespace in the github diff viewer if you want to view the diff more easily.
