### PR TITLE
Make sure kafkaConsumerGroupGen doesn't generate duplicates

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -755,7 +755,9 @@ class RealS3BackupClientSpec
        firstKafkaConsumerGroup: String,
        secondKafkaConsumerGroup: String
       ) =>
-        whenever(firstS3Config.dataBucket != secondS3Config.dataBucket) {
+        whenever(
+          firstS3Config.dataBucket != secondS3Config.dataBucket && firstKafkaConsumerGroup != secondKafkaConsumerGroup
+        ) {
           val data = kafkaDataWithTimePeriod.data
 
           val topics = data.map(_.topic).toSet

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -436,6 +436,7 @@ class RealS3BackupClientSpec
            s3ConfigGen(useVirtualDotHost, bucketPrefix),
            kafkaConsumerGroupGen
     ) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config, kafkaConsumerGroup: String) =>
+      logger.info(s"Data bucket is ${s3Config.dataBucket}")
       val data = kafkaDataWithTimePeriod.data
 
       val topics = data.map(_.topic).toSet
@@ -534,6 +535,7 @@ class RealS3BackupClientSpec
     forAll(kafkaDataWithTimePeriodsGen(100, 100, 1000, tailingSentinelValue = true),
            s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
+      logger.info(s"Data bucket is ${s3Config.dataBucket}")
       val data = kafkaDataWithTimePeriod.data
 
       implicit val config: S3Config = s3Config
@@ -621,6 +623,7 @@ class RealS3BackupClientSpec
           firstS3Config.dataBucket != secondS3Config.dataBucket && firstKafkaConsumerGroup != secondKafkaConsumerGroup
         ) {
           logger.info(s"Data bucket are ${firstS3Config.dataBucket} and ${secondS3Config.dataBucket}")
+
           val data = kafkaDataInChunksWithTimePeriod.data.flatten
 
           val topics = data.map(_.topic).toSet
@@ -758,6 +761,8 @@ class RealS3BackupClientSpec
         whenever(
           firstS3Config.dataBucket != secondS3Config.dataBucket && firstKafkaConsumerGroup != secondKafkaConsumerGroup
         ) {
+          logger.info(s"Data bucket are ${firstS3Config.dataBucket} and ${secondS3Config.dataBucket}")
+
           val data = kafkaDataWithTimePeriod.data
 
           val topics = data.map(_.topic).toSet


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

In the previous PR at https://github.com/aiven/guardian-for-apache-kafka/pull/258 I forgot to filter out generated kafka consumer groups if they happen to be exactly the same.

The PR also adds logging statements for buckets (some tests was missing this).
