### PR TITLE
Make cleanTopics also trigger if exception occurs

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientSpec.scala
@@ -134,11 +134,11 @@ class RealS3BackupClientSpec
                   downloadSource.via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]]).runWith(Sink.seq)
                 case None => throw new Exception(s"Expected object in bucket ${s3Config.dataBucket} with key $key")
               }
-          _ = cleanTopics(topics)
         } yield downloaded.toList.flatten.collect { case Some(reducedConsumerRecord) =>
           reducedConsumerRecord
         }
 
+        calculatedFuture.onComplete(_ => cleanTopics(topics))
         val downloaded = calculatedFuture.futureValue
 
         val downloadedGroupedAsKey = downloaded
@@ -244,7 +244,6 @@ class RealS3BackupClientSpec
                                       s"Expected object in bucket ${s3Config.dataBucket} with key $key"
                                     )
                                 }
-          _ = cleanTopics(topics)
         } yield {
           val first = firstDownloaded.toList.flatten.collect { case Some(reducedConsumerRecord) =>
             reducedConsumerRecord
@@ -256,6 +255,7 @@ class RealS3BackupClientSpec
           (first, second)
         }
 
+        calculatedFuture.onComplete(_ => cleanTopics(topics))
         val (firstDownloaded, secondDownloaded) = calculatedFuture.futureValue
 
         // Only care about ordering when it comes to key
@@ -365,11 +365,11 @@ class RealS3BackupClientSpec
                             case None =>
                               throw new Exception(s"Expected object in bucket ${s3Config.dataBucket} with key $key")
                           }
-          _ = cleanTopics(topics)
         } yield downloaded.toList.flatten.collect { case Some(reducedConsumerRecord) =>
           reducedConsumerRecord
         }
 
+        calculatedFuture.onComplete(_ => cleanTopics(topics))
         val downloaded = calculatedFuture.futureValue
 
         // Only care about ordering when it comes to key
@@ -455,11 +455,11 @@ class RealS3BackupClientSpec
 
             })
             .map(_.flatten)
-        _ = cleanTopics(topics)
       } yield downloaded.flatten.collect { case Some(reducedConsumerRecord) =>
         reducedConsumerRecord
       }
 
+      calculatedFuture.onComplete(_ => cleanTopics(topics))
       val downloaded = calculatedFuture.futureValue
 
       // Only care about ordering when it comes to key
@@ -645,7 +645,6 @@ class RealS3BackupClientSpec
                     downloadSource.via(CirceStreamSupport.decode[List[Option[ReducedConsumerRecord]]]).runWith(Sink.seq)
                   case None => throw new Exception(s"Expected object in bucket ${s3Config.dataBucket} with key $key")
                 }
-            _ = cleanTopics(topics)
           } yield (downloadedOne.toList.flatten.collect { case Some(reducedConsumerRecord) =>
                      reducedConsumerRecord
                    },
@@ -654,6 +653,7 @@ class RealS3BackupClientSpec
                    }
           )
 
+          calculatedFuture.onComplete(_ => cleanTopics(topics))
           val (downloadedOne, downloadedTwo) = calculatedFuture.futureValue
 
           val downloadedOneGroupedAsKey = downloadedOne
@@ -800,7 +800,6 @@ class RealS3BackupClientSpec
 
                 })
                 .map(_.flatten)
-            _ = cleanTopics(topics)
           } yield (downloadedOne.flatten.collect { case Some(reducedConsumerRecord) =>
                      reducedConsumerRecord
                    },
@@ -809,6 +808,7 @@ class RealS3BackupClientSpec
                    }
           )
 
+          calculatedFuture.onComplete(_ => cleanTopics(topics))
           val (downloadedOne, downloadedTwo) = calculatedFuture.futureValue
 
           // Only care about ordering when it comes to key

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientSpec.scala
@@ -126,10 +126,12 @@ class RealS3RestoreClientSpec
           _              <- akka.pattern.after(5 seconds)(restoreClient.restore)
           receivedTopics <- akka.pattern.after(1 minute)(eventualRestoredTopics.drainAndShutdown())
           asConsumerRecords = receivedTopics.map(KafkaClient.consumerRecordToReducedConsumerRecord)
-          _                 = cleanTopics(kafkaDataInChunksWithTimePeriodRenamedTopics.topics)
-          _                 = cleanTopics(renamedTopics)
         } yield asConsumerRecords.toList
 
+        calculatedFuture.onComplete { _ =>
+          cleanTopics(kafkaDataInChunksWithTimePeriodRenamedTopics.topics)
+          cleanTopics(renamedTopics)
+        }
         val restoredConsumerRecords = calculatedFuture.futureValue
 
         val restoredGroupedAsKey = restoredConsumerRecords


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Move the cleanupTopics into an `onComplete` method on the `Future` so it always occurs even if there is an exception in the test

# Why this way
In the previous PR at https://github.com/aiven/guardian-for-apache-kafka/pull/276 topicCleanup was added however since it was a normal statement in the `for` comprehension on a `Future` it wouldn't trigger if the test would throw an exception for some reason. This change fixes that (`onComplete` will trigger regardless if the `Future` completes successfully or not).
