### PR TITLE
Properly cleanup BackupClient after test finishes

### DIFF
--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -30,6 +30,8 @@ trait App[T <: KafkaClientInterface] extends LazyLogging {
 
   def shutdown(control: Consumer.Control): Future[Done] = {
     logger.info("Shutdown of Guardian detected")
-    control.shutdown()
+    val future = control.shutdown()
+    future.onComplete(_ => logger.info("Guardian shut down"))
+    future
   }
 }

--- a/cli-backup/src/test/resources/logback.xml
+++ b/cli-backup/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%highlight(%-5level)] %d{HH:mm:ss.SSS} %logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <!-- Logging for NetworkClient is turned off because in cli tests we are only testing if command line args
+    are passed in properly -->
+    <logger name="org.apache.kafka.clients.NetworkClient" level="OFF"/>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNCSTDOUT" />
+    </root>
+
+</configuration>

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
@@ -1,0 +1,23 @@
+package io.aiven.guardian.kafka.backup
+
+import akka.Done
+import akka.kafka.scaladsl.Consumer
+import akka.stream.Materializer
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+/** A wrapper that is designed to make it easier to cleanly shutdown resources in tests
+  */
+class BackupClientControlWrapper[T <: KafkaClient](backupClient: BackupClientInterface[T])(implicit
+    materializer: Materializer,
+    ec: ExecutionContext
+) {
+
+  private var control: Consumer.DrainingControl[Done] = _
+
+  def run(): Unit =
+    control = backupClient.backup.run()
+
+  def shutdown(): Future[Done] = control.drainAndShutdown()
+}

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+  log-dead-letters-during-shutdown = false
+  log-dead-letters = 0
+}


### PR DESCRIPTION
# About this change - What it does

Adds a mechanism to shut down the backup clients after each individual test is run

# Why this way

Due to the tests not being cleaned up properly a lot of output was being logged about clients not being able to connect anymore since the test was already finished. Another commit has also been added to remove the akka dead letter logging, i.e.

```
[INFO] [akkaDeadLetter][09/02/2022 20:10:30.238] [MinioS3BackupClientSpec-akka.actor.default-dispatcher-21] [akka://MinioS3BackupClientSpec/system/IO-TCP/selectors/$a/23] Message [akka.actor.ReceiveTimeout$] to Actor[akka://MinioS3BackupClientSpec/system/IO-TCP/selectors/$a/23#-1892879735] was not delivered. [4] dead letters encountered. If this is not an expected behavior then Actor[akka://MinioS3BackupClientSpec/system/IO-TCP/selectors/$a/23#-1892879735] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
```

Some other minor improvements have been made to logging output during tests (i.e. reduce logs in cli tests as well as logging when Guardian has successfully been shut down).
