### PR TITLE
Pin akka to version 2.6 due to license change

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,9 @@
 updatePullRequests = "always"
+
+# https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka
+updates.pin = [{ groupId = "com.typesafe.akka", version = "2.6." }]
+updates.ignore = [
+  { groupId = "com.typesafe.akka" },
+  { groupId = "com.lightbend.akka" },
+  { groupId = "com.lightbend.akka.grpc" }
+]


### PR DESCRIPTION
Due to akka changing their license an incompatible BSL in v 2.7.x, this PR limits scala steward so that it will never create a PR for an akka version that is not license compatible.

See https://github.com/akka/akka/pull/31561, https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka and https://www.lightbend.com/akka/license-faq