### PR TITLE
Add CLI bucket cleanup utility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,8 @@ lazy val coreS3 = project
       // security vulnerability gets resolved in Compile scope
       "com.typesafe.akka" %% "akka-http-xml"   % akkaHttpVersion,
       "org.scalatest"     %% "scalatest"       % scalaTestVersion           % Test,
-      "org.scalatestplus" %% "scalacheck-1-15" % scalaTestScalaCheckVersion % Test
+      "org.scalatestplus" %% "scalacheck-1-15" % scalaTestScalaCheckVersion % Test,
+      "com.monovore"      %% "decline"         % declineVersion             % Test
     )
   )
   .dependsOn(core % "compile->compile;test->test")

--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Main.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/Main.scala
@@ -1,0 +1,123 @@
+package io.aiven.guardian.kafka.s3
+
+import akka.actor.ActorSystem
+import akka.stream.Attributes
+import akka.stream.alpakka.s3.S3Attributes
+import akka.stream.alpakka.s3.S3Settings
+import akka.stream.alpakka.s3.scaladsl.S3
+import akka.stream.scaladsl.Sink
+import cats.data.NonEmptyList
+import cats.implicits._
+import com.monovore.decline.Command
+import com.monovore.decline.CommandApp
+import com.monovore.decline.Opts
+import com.typesafe.scalalogging.LazyLogging
+import io.aiven.guardian.kafka.s3.Entry.computeAndDeleteBuckets
+import markatta.futiles.Retry
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers.AwsRegionProvider
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.control.NonFatal
+
+class Entry
+    extends CommandApp(
+      name = "guardian-s3-test-utils",
+      header = "Guardian S3 Test Utilities",
+      main = {
+        val cleanBucketsCommand = Command(
+          name = "clean-buckets",
+          header = "Clean buckets left over by Guardian S3 tests"
+        ) {
+          val prefixOpt: Opts[String] =
+            Opts
+              .option[String]("prefix", help = "Only delete buckets with specified prefix")
+
+          val excludeBucketsOpt: Opts[Option[NonEmptyList[String]]] =
+            Opts
+              .options[String]("exclude-buckets",
+                               help = "Buckets that will always be excluded from cleanup, irrespective of prefix"
+              )
+              .orNone
+
+          (prefixOpt, excludeBucketsOpt).tupled
+        }
+
+        Opts.subcommand(cleanBucketsCommand).map { case (bucketPrefix, excludeBuckets) =>
+          implicit val system: ActorSystem    = ActorSystem()
+          implicit val ec: ExecutionContext   = system.dispatcher
+          implicit val s3Settings: S3Settings = S3Settings()
+
+          val excludeBucketsSet = excludeBuckets.map(_.toList.toSet).getOrElse(Set.empty)
+
+          try {
+            Await.result(computeAndDeleteBuckets(bucketPrefix, excludeBucketsSet), Duration.Inf)
+            System.exit(0)
+          } catch {
+            case NonFatal(_) =>
+              System.exit(1)
+          }
+        }
+      }
+    )
+
+object Entry extends LazyLogging {
+  def computeAndDeleteBuckets(bucketPrefix: String, excludeBuckets: Set[String])(implicit
+      executionContext: ExecutionContext,
+      system: ActorSystem,
+      s3Settings: S3Settings
+  ): Future[Set[String]] = for {
+    bucketsToDelete <- computeBucketsToDelete(bucketPrefix, excludeBuckets)
+    _ <- if (bucketsToDelete.nonEmpty) {
+           deleteBuckets(bucketsToDelete)
+         } else
+           Future {
+             logger.info("No buckets to delete")
+           }
+  } yield bucketsToDelete
+
+  def computeBucketsToDelete(bucketPrefix: String, excludeBuckets: Set[String])(implicit
+      system: ActorSystem,
+      s3Settings: S3Settings
+  ): Future[Set[String]] =
+    // Bug that needs to be fixed upstream in Alpakka, this specific S3 api call is not region specific
+    // so US_EAST_1 needs to be hardcoded
+    S3.listBuckets()
+      .withAttributes(S3Attributes.settings(s3Settings.withS3RegionProvider(new AwsRegionProvider {
+        val getRegion: Region = Region.US_EAST_1
+      })))
+      .runWith(Sink.seq)
+      .map { allBuckets =>
+        allBuckets.map(_.name).toSet.filter(fromS3Bucket => fromS3Bucket.startsWith(bucketPrefix)).diff(excludeBuckets)
+      }(ExecutionContext.parasitic)
+
+  def deleteBuckets(
+      buckets: Set[String]
+  )(implicit executionContext: ExecutionContext, system: ActorSystem, s3Settings: S3Settings): Future[Unit] = {
+    implicit val s3Attrs: Attributes = S3Attributes.settings(s3Settings)
+    val futures = buckets.map { bucket =>
+      logger.info(s"Deleting bucket $bucket")
+      for {
+        _ <- S3.deleteBucketContents(bucket).withAttributes(s3Attrs).runWith(Sink.ignore)
+        multiParts <-
+          S3.listMultipartUpload(bucket, None).withAttributes(s3Attrs).runWith(Sink.seq)
+        _ <- Future.sequence(multiParts.map { part =>
+               for {
+                 _ <- S3.deleteUpload(bucket, part.key, part.uploadId)
+               } yield ()
+             })
+        _ <- Retry.retryWithBackOff(
+               5,
+               100 millis,
+               throwable => throwable.getMessage.contains("The bucket you tried to delete is not empty")
+             )(S3.deleteBucket(bucket))
+        _ = logger.info(s"Completed deleting bucket $bucket")
+      } yield ()
+    }
+    Future.sequence(futures).map(_ => ())(ExecutionContext.parasitic)
+  }
+}
+
+object Main extends Entry

--- a/docs/src/main/paradox/testing/s3.md
+++ b/docs/src/main/paradox/testing/s3.md
@@ -11,6 +11,20 @@ export ALPAKKA_S3_REGION_PROVIDER=static
 export ALPAKKA_S3_REGION_DEFAULT_REGION=eu-central-1
 ```
 
+## Utilities
+
+Guardian provides a utility to help deal with running S3 related tests. Due to the possibility of this tool
+making unintentional consequences to your S3 account, it needs to be manually run in sbt. To run the tool
+without any parameters do this
+
+```sh
+sbt "coreS3/test:runMain io.aiven.guardian.kafka.s3.Main"
+```
+
+Current commands
+
+* `cleanup-buckets`: Helps in cleaning up S3 buckets that have been inadvertently left over by tests.
+
 ## Tagging S3 Tests
 
 Due to a current limitation where there is no way to expose Github secrets to PR's made from external forks, tests which


### PR DESCRIPTION
# About this change - What it does

Adds a CLI utility for cleaning up buckets that have been left over in S3 tests

# Why this way

This functionality is added as a standard `Main` class however due to the ability CLI tool to do damage to an S3 account its placed in the `test` scope, it's not packaged and it has to be executed manually via sbt. To further improve the safety of the tool, you must provide a mandatory `prefix` parameter when running it.

Documentation has also been added on how to use the tool.
