### PR TITLE
Add documentation for property/flaky tests

### DIFF
--- a/docs/src/main/paradox/testing/index.md
+++ b/docs/src/main/paradox/testing/index.md
@@ -16,8 +16,70 @@ using this testing framework are
 * It provides very handy utilities for testing asynchronous code, for example a
   @extref:[PatienceConfig](scalatest:concurrent/AbstractPatienceConfiguration$PatienceConfig.html)
   that provides efficient polling of Scala futures with configurable scalable timeouts and intervals.
-* Akka provides @extref:[Testkit](akka-docs:testing.html#asynchronous-testing-testkit) with direct integration into ScalaTest
-  for easy testing of akka-streams.
+* Akka provides @extref:[Testkit](akka-docs:testing.html#asynchronous-testing-testkit) with direct integration into
+  ScalaTest for easy testing of akka-streams.
+
+### Property based tests
+
+Guardian for Apache Kafka emphasises using property based testing over unit based tests. This is mainly due
+to the fact that property based tests often reveal more problems due to covering more cases compared to unit
+based tests. Here are more [details](https://www.scalatest.org/user_guide/generator_driven_property_checks)
+on how property based testing works with Scala.
+
+Like most random data generation, ScalaTest/ScalaCheck relies on an initial seed to deterministically generate
+the data. When a test fails the seed for the failing test is automatically shown (search for `Init Seed: `).
+If you want to specify the seed to regenerate the exact same data that caused the test to fail, you need to
+specify it as a test argument in `sbt`
+
+```sbt
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-S", "7832168009826873070")
+```
+
+where `7832168009826873070` happens to be the seed
+
+This argument can be put into any of the projects within the @github[build](/build.sbt). For example if you
+want to only specify the speed in the `core` project you can place it like so
+
+```sbt
+lazy val core = project
+  .in(file("core"))
+  .settings(
+    librarySettings,
+    name := s"$baseName-core",
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-S", "7832168009826873070"),
+```
+
+Whereas if you want it to apply globally you can just place it in the `guardian` project.
+
+## Running test/s until failure
+
+When diagnosing flaky tests it's very useful to be able to run a test until it fails which sbt allows you to
+do with [commands](https://www.scala-sbt.org/1.x/docs/Commands.html). Doing this using a sbt command
+is far quicker than other options such a shell script since you don't have to deal with startup time cost for
+every test run.
+
+This is what the base command looks like
+
+```sbt
+commands += Command.command("testUntilFailed") { state =>
+  "test" :: "testUntilFailed" :: state
+}
+```
+
+The command will recursively call a specific task (in this case `test`) until it fails. For it to work with
+Guardin for Apache Kafka's @github[build](/build.sbt), you need to place it as a setting
+within the `guardian` project.
+
+Note that this works with any command, not just `test`. For example if you want to only run a single test
+suite until failure you can do
+
+```sbt
+commands += Command.command("testUntilFailed") { state =>
+  "backupS3/testOnly io.aiven.guardian.kafka.backup.s3.MockedKafkaClientBackupClientSpec" :: "testUntilFailed" :: state
+}
+```
+
+Once specified in the @github[build](/build.sbt) file you can then run `testUntilFailed` within the sbt shell.
 
 ## TestContainers
 


### PR DESCRIPTION
This PR adds documentation on how to deal with property/flaky tests for Guardian.