### PR TITLE
Update alpakka-kafka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/c
 
 val akkaVersion                = "2.6.20"
 val akkaHttpVersion            = "10.2.10"
-val alpakkaKafkaVersion        = "3.0.0"
+val alpakkaKafkaVersion        = "3.0.1"
 val kafkaClientsVersion        = "3.2.2"
 val alpakkaVersion             = "4.0.0"
 val futilesVersion             = "2.0.2"


### PR DESCRIPTION
Update alpakka-kafka version, note that this is the last Apacha2 release https://mvnrepository.com/artifact/com.typesafe.akka/akka-stream-kafka_2.13/3.0.1