### PR TITLE
Specify max to throttle argument

### DIFF
--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -199,7 +199,7 @@ trait S3Spec
   ): Source[ProducerRecord[Array[Byte], Array[Byte]], NotUsed] = {
     val durationToMicros = streamDuration.toMillis
     val topicsPerMillis  = producerRecords.size / durationToMicros
-    Source(producerRecords).throttle(topicsPerMillis.toInt, 1 millis)
+    Source(producerRecords).throttle(topicsPerMillis.toInt max 1, 1 millis)
   }
 
   /** Converts a generated list of `ReducedConsumerRecord` to a list of `ProducerRecord`


### PR DESCRIPTION
# About this change - What it does

Makes sure that the argument to throttle is always at least 1

# Why this way

The argument to throttle must always be greater than 0

```
[info] - Round-trip with backup and restore *** FAILED ***
[info]   IllegalArgumentException was thrown during property evaluation.
[info]     Message: requirement failed: cost must be > 0
[info]     Occurred when passed generated values (
```

With the division the result could end up being truncated to 0 so this PR makes sure it is always at least 1.
