### PR TITLE
Use Range for padTimestampsMillis to fix test flakiness

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupClientSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupClientSpec.scala
@@ -44,8 +44,13 @@ class MockedKafkaClientBackupClientSpec
     "Creating many objects in a small period of time works despite S3's in progress multipart upload eventual consistency issues",
     RealS3Available
   ) {
-    forAll(kafkaDataWithTimePeriodsGen(100, 100, 1000, tailingSentinelValue = true),
-           s3ConfigGen(useVirtualDotHost, bucketPrefix)
+    forAll(
+      kafkaDataWithTimePeriodsGen(20,
+                                  20,
+                                  padTimestampsMillis = Range.inclusive(1000, 1000),
+                                  trailingSentinelValue = true
+      ),
+      s3ConfigGen(useVirtualDotHost, bucketPrefix)
     ) { (kafkaDataWithTimePeriod: KafkaDataWithTimePeriod, s3Config: S3Config) =>
       logger.info(s"Data bucket is ${s3Config.dataBucket}")
       val data = kafkaDataWithTimePeriod.data

--- a/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceSpec.scala
+++ b/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceSpec.scala
@@ -39,7 +39,8 @@ class RestoreClientInterfaceSpec
 
   property("Calculating finalKeys contains correct keys with fromWhen filter") {
     forAll(
-      kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis = ChronoUnit.HOURS.getDuration.toMillis.toInt,
+      kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis =
+                                                   Range.inclusive(1, ChronoUnit.HOURS.getDuration.toMillis.toInt),
                                                  min = 1000,
                                                  max = 1000
       )
@@ -103,7 +104,8 @@ class RestoreClientInterfaceSpec
 
   property("Round-trip with backup and restore works using fromWhen filter") {
     forAll(
-      kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis = ChronoUnit.HOURS.getDuration.toMillis.toInt,
+      kafkaDataWithTimePeriodsAndPickedRecordGen(padTimestampsMillis =
+                                                   Range.inclusive(1, ChronoUnit.HOURS.getDuration.toMillis.toInt),
                                                  min = 1000,
                                                  max = 1000
       )


### PR DESCRIPTION
# About this change - What it does

Modifies the `padTimestampsMillis` so that it accepts the Scala `Range` type rather than Int and modifies the `MockedKafkaClientBackupClientSpec` so that it uses `Range.inclusive(1000, 1000)` for `padTimestampsMillis` which removes the randomness from the test. `tailingSentinelValue` has also been renamed to `trailingSentinelValue`.

Resolves: #290

# Why this way

Due to the computation of `kafkaDataWithTimePeriodsGen(100, 100, 1000, tailingSentinelValue = true)` generating random values along with a `PeriodFromFirst` configuration of `1 second` created situations where the `MockedKafkaClientBackupClientSpec` can randomly fail due to not creating a processing boundary for calculating the time slice and hence some data being missed in the final match.

To fix this `padTimestampsMillis` has been changed to a `Range` which allows precise control on the padding of the timestamps between consecutive elements in the generated `ReducedConsumerRecord`'s. As seen in the test, this means you can provide a value of `Range.inclusive(1000, 1000)` which generates a precise (i.e. non random `timestmap`) list of `ReducedConsumerRecord` with each element being 1 second later than the previous.

Note that for this specific test, having randomness in the generated timestamps is not critical. The whole point of the test is to make sure that Guardian's backup can deal with the fact that S3 is eventually consistent and it tests this by creating a lot of S3 objects in a small period of time. If you put `data.foreach(record => println(record.timestamp))` into the test we can see that the `Range(1000, 1000)` is working as intended, i.e.

```
1
1001
2001
3001
4001
5001
6001
7001
8001
9001
10001
11001
12001
13001
14001
15001
16001
17001
18001
19001
1663507868262
```
Note that the last `1663507868262` is the `trailingSentinelValue` (its meant to be that large).

I have ran this test in a loop for 10 hours in the actual github actions CI as well as locally and have not received a failure.