### PR TITLE
Fix scoverage

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.codecommit"                    % "sbt-github-actions"       % 
 addSbtPlugin("com.github.sbt"                    % "sbt-pgp"                  % "2.1.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-release"              % "1.1.0")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"             % "0.10.1")
-addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.2")
+addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.3")
 addSbtPlugin("org.scoverage"                     % "sbt-coveralls"            % "1.3.2")
 addSbtPlugin("net.vonbuchholtz"                  % "sbt-dependency-check"     % "4.1.0")
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This PR updates scoverage.

# Why this way

Ever since https://github.com/aiven/guardian-for-apache-kafka/pull/261 was merged scoverage wasn't working, this PR fixes that. See https://github.com/scoverage/sbt-coveralls/issues/199 and https://github.com/scoverage/scalac-scoverage-plugin/pull/497 for the reason why scoverage broke in the update
