### PR TITLE
Adjust Mocks to handle kafka commits

### DIFF
--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaClientInterface.scala
@@ -7,21 +7,33 @@ import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicReference
 
 /** A mocked `KafkaClientInterface` that returns a specific data as its source
+  *
   * @param kafkaData
   *   The data which the mock will output
-  * @param sourceTransform
-  *   A function that allows you to transform the source in some way. Convenient for cases such as throttling. By
-  *   default this is `None` so it just preserves the original source.
+  * @param commitStorage
+  *   A collection that keeps track of whenever a cursor is committed
+  * @param stopAfterDuration
+  *   Dont produce any data from `kafkaData` if its offset is after `stopAfterOffset` based off of the first committed
+  *   [[io.aiven.guardian.kafka.models.ReducedConsumerRecord.timestamp]]. Handy to simulate the premature closing of a
+  *   KafkaClient before its completed producing all source elements (i.e. suspend/resume and restart scenarios).
+  * @param handleOffsets
+  *   Tells the MockedKafkaClientInterface to handleOffsets rather than just ignoring them. This means that the mock
+  *   will only add commits to the `commitStorage` if its later than any currently processed offsets. Furthermore it
+  *   will not replay source data if it has already been committed.
   */
-class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUsed]) extends KafkaClientInterface {
-
-  /** A collection that keeps track of whenever a cursor is committed
-    */
-  val committedOffsets: ConcurrentLinkedQueue[Long] = new ConcurrentLinkedQueue[Long]()
+class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUsed],
+                                 commitStorage: ConcurrentLinkedDeque[Long] = new ConcurrentLinkedDeque[Long](),
+                                 stopAfterDuration: Option[FiniteDuration] = None,
+                                 handleOffsets: Boolean = false
+) extends KafkaClientInterface {
 
   /** The type of the context to pass around. In context of a Kafka consumer, this typically holds offset data to be
     * automatically committed
@@ -41,15 +53,50 @@ class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUse
     */
   override type BatchedCursorContext = Long
 
+  private val firstReducedConsumerRecord: AtomicReference[ReducedConsumerRecord] =
+    new AtomicReference[ReducedConsumerRecord]()
+
   /** @return
     *   A `SourceWithContext` that returns a Kafka Stream which automatically handles committing of cursors
     */
-  override def getSource: SourceWithContext[ReducedConsumerRecord, Long, Future[NotUsed]] =
+  override def getSource: SourceWithContext[ReducedConsumerRecord, Long, Future[NotUsed]] = {
+    val source = kafkaData
+      .prefixAndTail(1)
+      .flatMapConcat {
+        case (Seq(head), rest) =>
+          firstReducedConsumerRecord.set(head)
+          Source.combine(
+            Source.single(head),
+            rest
+          )(Concat(_))
+        case _ => Source.empty[ReducedConsumerRecord]
+      }
+
+    val finalSource = if (handleOffsets) {
+      source.filter { reducedConsumerRecord =>
+        (commitStorage.isEmpty || {
+          reducedConsumerRecord.offset > commitStorage.getLast
+        }) && {
+          (stopAfterDuration, Option(firstReducedConsumerRecord.get())) match {
+            case (Some(afterDuration), Some(firstRecord)) =>
+              val difference =
+                ChronoUnit.MILLIS.between(Instant.ofEpochMilli(firstRecord.timestamp),
+                                          Instant.ofEpochMilli(reducedConsumerRecord.timestamp)
+                )
+              afterDuration.toMillis > difference
+            case _ => true
+          }
+        }
+      }
+    } else
+      source
+
     SourceWithContext
-      .fromTuples(kafkaData.map { reducedConsumerRecord =>
+      .fromTuples(finalSource.map { reducedConsumerRecord =>
         (reducedConsumerRecord, reducedConsumerRecord.offset)
       })
       .mapMaterializedValue(Future.successful)
+  }
 
   /** @return
     *   The result of this function gets directly passed into the `combine` parameter of
@@ -60,7 +107,13 @@ class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUse
   /** @return
     *   A `Sink` that allows you to commit a `CursorContext` to Kafka to signify you have processed a message
     */
-  override def commitCursor: Sink[Long, Future[Done]] = Sink.foreach(cursor => committedOffsets.add(cursor))
+  override def commitCursor: Sink[Long, Future[Done]] = Sink.foreach { cursor =>
+    if (handleOffsets && !commitStorage.isEmpty) {
+      if (commitStorage.getLast < cursor)
+        commitStorage.add(cursor)
+    } else
+      commitStorage.add(cursor)
+  }
 
   /** How to batch an immutable iterable of `CursorContext` into a `BatchedCursorContext`
     * @param cursors


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Adjusts various mocks so that they are able to handle the suspend/resume case in Guardian. Also adds a test which makes sure the mocks work.

# Why this way

The context of this PR is for the gzip compression PR at https://github.com/aiven/guardian-for-apache-kafka/pull/196. In that gzip compression PR I want to add a test which makes sure that restarting the tool between changing the gzip configuration works (i.e. first start guardian with gzip compression on, shut down guardian, then turn on Guardian again with gzip compression off). While its possible to test this using a real Kafka/S3, its excessive since I only want to test that the compression changes apply.

The basis of the PR is to add data structures (`backedUpData`/`commitStorage`) that is shared between `mockOne`/`mockTwo` in order to share the relevant state between multiple instances of the mock as well as a `handleCommits` flag which enables the tracking of commits in the mocks. Logic also needed to be added to the mocks to actually handle the case of suspend/resume case. The `stopAfterDuration` has been added to simulate the "suspend" scenario (with a real Kafka/Backup client we just terminate the client while its backing up where as with a mock it will produce and backup the elements immediately so "stopAfterDuration" is needed and its implemented as simple filter that will just stop producing elements after a specific time period).

There is also a bug in the `Generator` regarding offset generation. This was solved by just using `zipWithIndex` (since the mocks only generate a single topic with a hardcoded partition, the commit counter is just a globally monotonously incrementing counter). 
