### PR TITLE
Minor fixes

### DIFF
--- a/cli-backup/src/test/scala/io/aiven/guardian/kafka/backup/CliSpec.scala
+++ b/cli-backup/src/test/scala/io/aiven/guardian/kafka/backup/CliSpec.scala
@@ -2,6 +2,7 @@ package io.aiven.guardian.kafka.backup
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.{Backup => BackupConfig}
 import io.aiven.guardian.kafka.configs.{KafkaCluster => KafkaClusterConfig}
@@ -21,7 +22,12 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
 @nowarn("msg=method main in class CommandApp is deprecated")
-class CliSpec extends TestKit(ActorSystem("BackupCliSpec")) with AnyPropSpecLike with Matchers with ScalaFutures {
+class CliSpec
+    extends TestKit(ActorSystem("BackupCliSpec"))
+    with AnyPropSpecLike
+    with Matchers
+    with ScalaFutures
+    with StrictLogging {
   implicit val ec: ExecutionContext                    = system.dispatcher
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(5 minutes, 100 millis)
 

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -311,7 +311,7 @@ class BackupClientInterfaceSpec
         commitStorage,
         backupStorage,
         stopAfterDuration = Some(kafkaDataWithTimePeriod.periodSlice),
-        trackCommits = true
+        handleOffsets = true
       )
 
       val mockTwo = new MockedBackupClientInterfaceWithMockedKafkaData(Source(data),
@@ -319,7 +319,7 @@ class BackupClientInterfaceSpec
                                                                        commitStorage,
                                                                        backupStorage,
                                                                        stopAfterDuration = None,
-                                                                       trackCommits = true
+                                                                       handleOffsets = true
       )
 
       val calculatedFuture = for {

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientInterfaceSpec.scala
@@ -7,6 +7,7 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
+import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.akka.AkkaStreamTestKit
 import io.aiven.guardian.akka.AnyPropTestKit
 import io.aiven.guardian.kafka.Generators.KafkaDataWithTimePeriod
@@ -41,7 +42,8 @@ class BackupClientInterfaceSpec
     with AkkaStreamTestKit
     with Matchers
     with ScalaFutures
-    with ScalaCheckPropertyChecks {
+    with ScalaCheckPropertyChecks
+    with StrictLogging {
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(90 seconds, 100 millis)

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -146,12 +146,12 @@ class MockedBackupClientInterfaceWithMockedKafkaData(
     kafkaData: Source[ReducedConsumerRecord, NotUsed],
     timeConfiguration: TimeConfiguration,
     commitStorage: ConcurrentLinkedDeque[Long] = new ConcurrentLinkedDeque[Long](),
-    backupStorage: ConcurrentLinkedQueue[(String, ByteString)] = new ConcurrentLinkedQueue[(String, ByteString)](),
+    backedUpData: ConcurrentLinkedQueue[(String, ByteString)] = new ConcurrentLinkedQueue[(String, ByteString)](),
     stopAfterDuration: Option[FiniteDuration] = None,
-    trackCommits: Boolean = false
+    handleOffsets: Boolean = false
 )(implicit override val system: ActorSystem)
     extends MockedBackupClientInterface(
-      new MockedKafkaClientInterface(kafkaData, commitStorage, stopAfterDuration, trackCommits),
+      new MockedKafkaClientInterface(kafkaData, commitStorage, stopAfterDuration, handleOffsets),
       timeConfiguration,
-      backupStorage
+      backedUpData
     )

--- a/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceSpec.scala
+++ b/core-restore/src/test/scala/io/aiven/guardian/kafka/restore/RestoreClientInterfaceSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
+import com.typesafe.scalalogging.StrictLogging
 import io.aiven.guardian.akka.AkkaStreamTestKit
 import io.aiven.guardian.akka.AnyPropTestKit
 import io.aiven.guardian.kafka.ExtensionsMethods._
@@ -32,7 +33,8 @@ class RestoreClientInterfaceSpec
     with AkkaStreamTestKit
     with Matchers
     with ScalaFutures
-    with ScalaCheckPropertyChecks {
+    with ScalaCheckPropertyChecks
+    with StrictLogging {
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(90 seconds, 100 millis)


### PR DESCRIPTION
# About this change - What it does

This PR contains some minor fixes, i.e.

* In the previous PR at https://github.com/aiven/guardian-for-apache-kafka/pull/302 some parameter names
* There is an issue whereby slf4j complains that logs were made during initialisation of logging, adding in `StrictLogging` into the traits forces the initialisation to happen instantly.