### PR TITLE
Rename KafkaClient and KafkaClientInterface

### DIFF
--- a/backup-gcs/src/main/scala/io/aiven/guardian/kafka/backup/gcs/BackupClient.scala
+++ b/backup-gcs/src/main/scala/io/aiven/guardian/kafka/backup/gcs/BackupClient.scala
@@ -9,7 +9,7 @@ import akka.stream.alpakka.googlecloud.storage.scaladsl.GCStorage
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import io.aiven.guardian.kafka.backup.BackupClientInterface
-import io.aiven.guardian.kafka.backup.KafkaClientInterface
+import io.aiven.guardian.kafka.backup.KafkaConsumerInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.gcs.configs.{GCS => GCSConfig}
 
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 
 // TODO: GCS implementation currently does not work correctly because of inability of current GCS implementation in
 // Alpakka to allow us to commit Kafka cursor whenever chunks are uploaded
-class BackupClient[T <: KafkaClientInterface](maybeGoogleSettings: Option[GoogleSettings])(implicit
+class BackupClient[T <: KafkaConsumerInterface](maybeGoogleSettings: Option[GoogleSettings])(implicit
     override val kafkaClientInterface: T,
     override val backupConfig: Backup,
     override val system: ActorSystem,

--- a/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
+++ b/backup-s3/src/main/scala/io/aiven/guardian/kafka/backup/s3/BackupClient.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl._
 import akka.util.ByteString
 import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.backup.BackupClientInterface
-import io.aiven.guardian.kafka.backup.KafkaClientInterface
+import io.aiven.guardian.kafka.backup.KafkaConsumerInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.models.BackupObjectMetadata
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 
 import java.time.Instant
 
-class BackupClient[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings])(implicit
+class BackupClient[T <: KafkaConsumerInterface](maybeS3Settings: Option[S3Settings])(implicit
     override val kafkaClientInterface: T,
     override val backupConfig: Backup,
     override val system: ActorSystem,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientChunkState.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/BackupClientChunkState.scala
@@ -6,7 +6,7 @@ import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.alpakka.s3.SuccessfulUploadPart
 import akka.stream.scaladsl.Sink
-import io.aiven.guardian.kafka.backup.KafkaClientInterface
+import io.aiven.guardian.kafka.backup.KafkaConsumerInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.s3.configs.{S3 => S3Config}
 
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-class BackupClientChunkState[T <: KafkaClientInterface](maybeS3Settings: Option[S3Settings])(implicit
+class BackupClientChunkState[T <: KafkaConsumerInterface](maybeS3Settings: Option[S3Settings])(implicit
     override val kafkaClientInterface: T,
     override val backupConfig: Backup,
     override val system: ActorSystem,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaConsumerWithKillSwitch.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/KafkaConsumerWithKillSwitch.scala
@@ -7,12 +7,12 @@ import akka.kafka.ConsumerSettings
 import akka.kafka.scaladsl.Consumer
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.SourceWithContext
-import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.configs.KafkaCluster
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 
-class KafkaClientWithKillSwitch(
+class KafkaConsumerWithKillSwitch(
     configureConsumer: Option[
       ConsumerSettings[Array[Byte], Array[Byte]] => ConsumerSettings[Array[Byte], Array[Byte]]
     ] = None,
@@ -21,7 +21,7 @@ class KafkaClientWithKillSwitch(
     ] = None,
     killSwitch: SharedKillSwitch
 )(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster, backupConfig: Backup)
-    extends KafkaClient(configureConsumer, configureCommitter) {
+    extends KafkaConsumer(configureConsumer, configureCommitter) {
   override def getSource
       : SourceWithContext[ReducedConsumerRecord, ConsumerMessage.CommittableOffset, Consumer.Control] =
     super.getSource.via(killSwitch.flow)

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedKafkaClientBackupConsumerSpec.scala
@@ -10,7 +10,7 @@ import io.aiven.guardian.akka.AnyPropTestKit
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.Utils
 import io.aiven.guardian.kafka.backup.MockedBackupClientInterface
-import io.aiven.guardian.kafka.backup.MockedKafkaClientInterface
+import io.aiven.guardian.kafka.backup.MockedKafkaConsumerInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
 import io.aiven.guardian.kafka.codecs.Circe._
@@ -27,7 +27,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class MockedKafkaClientBackupClientSpec
+class MockedKafkaClientBackupConsumerSpec
     extends AnyPropTestKit(ActorSystem("MockedKafkaClientBackupClientSpec"))
     with S3Spec
     with Matchers {
@@ -60,7 +60,7 @@ class MockedKafkaClientBackupClientSpec
         Backup(MockedBackupClientInterface.KafkaGroupId, PeriodFromFirst(1 second), 10 seconds, None)
 
       val backupClient =
-        new BackupClient(Some(s3Settings))(new MockedKafkaClientInterface(Source(data)),
+        new BackupClient(Some(s3Settings))(new MockedKafkaConsumerInterface(Source(data)),
                                            implicitly,
                                            implicitly,
                                            implicitly,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/MockedS3BackupClientInterface.scala
@@ -6,7 +6,7 @@ import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.S3Settings
 import akka.stream.scaladsl.Source
 import io.aiven.guardian.kafka.backup.MockedBackupClientInterface
-import io.aiven.guardian.kafka.backup.MockedKafkaClientInterface
+import io.aiven.guardian.kafka.backup.MockedKafkaConsumerInterface
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.TimeConfiguration
 import io.aiven.guardian.kafka.models.ReducedConsumerRecord
@@ -24,7 +24,7 @@ class MockedS3BackupClientInterface(
     extends BackupClient(
       maybeS3Settings
     )(
-      new MockedKafkaClientInterface(kafkaData),
+      new MockedKafkaConsumerInterface(kafkaData),
       Backup(MockedBackupClientInterface.KafkaGroupId, timeConfiguration, 10 seconds, None),
       implicitly,
       s3Config,

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
@@ -13,7 +13,7 @@ import io.aiven.guardian.kafka.KafkaClusterTest
 import io.aiven.guardian.kafka.TestUtils._
 import io.aiven.guardian.kafka.Utils
 import io.aiven.guardian.kafka.backup.BackupClientControlWrapper
-import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.ChronoUnitSlice
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
@@ -47,8 +47,8 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
   def createKafkaClient(
       killSwitch: SharedKillSwitch
-  )(implicit kafkaClusterConfig: KafkaCluster, backupConfig: Backup): KafkaClientWithKillSwitch =
-    new KafkaClientWithKillSwitch(
+  )(implicit kafkaClusterConfig: KafkaCluster, backupConfig: Backup): KafkaConsumerWithKillSwitch =
+    new KafkaConsumerWithKillSwitch(
       configureConsumer = baseKafkaConfig,
       killSwitch = killSwitch
     )
@@ -120,7 +120,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
         val backupClientWrapped =
           new BackupClientControlWrapper(
-            new BackupClient(Some(s3Settings))(new KafkaClient(configureConsumer = baseKafkaConfig),
+            new BackupClient(Some(s3Settings))(new KafkaConsumer(configureConsumer = baseKafkaConfig),
                                                implicitly,
                                                implicitly,
                                                implicitly,
@@ -204,7 +204,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
         val backupClientWrapped = new BackupClientControlWrapper(backupClient)
 
         val secondBackupClient = new BackupClient(Some(s3Settings))(
-          new KafkaClient(configureConsumer = baseKafkaConfig),
+          new KafkaConsumer(configureConsumer = baseKafkaConfig),
           implicitly,
           implicitly,
           implicitly,
@@ -324,7 +324,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
         val secondBackupClient =
           new BackupClient(Some(s3Settings))(
-            new KafkaClient(configureConsumer = baseKafkaConfig),
+            new KafkaConsumer(configureConsumer = baseKafkaConfig),
             implicitly,
             implicitly,
             implicitly,
@@ -409,7 +409,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
         Backup(kafkaConsumerGroup, PeriodFromFirst(1 second), 10 seconds, compression)
       val backupClientWrapped =
         new BackupClientControlWrapper(
-          new BackupClient(Some(s3Settings))(new KafkaClient(configureConsumer = baseKafkaConfig),
+          new BackupClient(Some(s3Settings))(new KafkaConsumer(configureConsumer = baseKafkaConfig),
                                              implicitly,
                                              implicitly,
                                              implicitly,
@@ -505,7 +505,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
             new BackupClientControlWrapper(
               new BackupClient(Some(s3Settings))(
-                new KafkaClient(configureConsumer = baseKafkaConfig),
+                new KafkaConsumer(configureConsumer = baseKafkaConfig),
                 implicitly,
                 implicitly,
                 firstS3Config,
@@ -520,7 +520,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
             new BackupClientControlWrapper(
               new BackupClient(Some(s3Settings))(
-                new KafkaClient(configureConsumer = baseKafkaConfig),
+                new KafkaConsumer(configureConsumer = baseKafkaConfig),
                 implicitly,
                 implicitly,
                 secondS3Config,
@@ -630,7 +630,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
             new BackupClientControlWrapper(
               new BackupClient(Some(s3Settings))(
-                new KafkaClient(configureConsumer = baseKafkaConfig),
+                new KafkaConsumer(configureConsumer = baseKafkaConfig),
                 implicitly,
                 implicitly,
                 firstS3Config,
@@ -645,7 +645,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
 
             new BackupClientControlWrapper(
               new BackupClient(Some(s3Settings))(
-                new KafkaClient(configureConsumer = baseKafkaConfig),
+                new KafkaConsumer(configureConsumer = baseKafkaConfig),
                 implicitly,
                 implicitly,
                 secondS3Config,

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/App.scala
@@ -7,15 +7,15 @@ import akka.stream.ActorAttributes
 import akka.stream.Supervision
 import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.kafka.backup.BackupClientInterface
-import io.aiven.guardian.kafka.backup.KafkaClient
-import io.aiven.guardian.kafka.backup.KafkaClientInterface
+import io.aiven.guardian.kafka.backup.KafkaConsumer
+import io.aiven.guardian.kafka.backup.KafkaConsumerInterface
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-trait App[T <: KafkaClientInterface] extends LazyLogging {
+trait App[T <: KafkaConsumerInterface] extends LazyLogging {
   implicit val kafkaClient: T
-  implicit val backupClient: BackupClientInterface[KafkaClient]
+  implicit val backupClient: BackupClientInterface[KafkaConsumer]
   implicit val actorSystem: ActorSystem
   implicit val executionContext: ExecutionContext
 

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupApp.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupApp.scala
@@ -1,10 +1,10 @@
 package io.aiven.guardian.kafka.backup
 
 import io.aiven.guardian.cli.AkkaSettings
-import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.{Config => BackupConfig}
 import io.aiven.guardian.kafka.{Config => KafkaConfig}
 
 trait BackupApp extends BackupConfig with KafkaConfig with AkkaSettings {
-  implicit lazy val kafkaClient: KafkaClient = new KafkaClient()
+  implicit lazy val kafkaClient: KafkaConsumer = new KafkaConsumer()
 }

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/Main.scala
@@ -141,11 +141,11 @@ class Entry(val initializedApp: AtomicReference[Option[(App[_], Promise[Unit])]]
                   override lazy val kafkaClusterConfig: KafkaCluster = kafkaCluster
                   override lazy val s3Config: S3                     = s3
                   override lazy val backupConfig: Backup             = backup
-                  override lazy val kafkaClient: KafkaClient = {
+                  override lazy val kafkaClient: KafkaConsumer = {
                     val finalConsumerSettings =
                       (propertiesConsumerSettings.toList ++ bootstrapConsumerSettings.toList).reduceLeft(_ andThen _)
 
-                    new KafkaClient(Some(finalConsumerSettings))(actorSystem, kafkaClusterConfig, backupConfig)
+                    new KafkaConsumer(Some(finalConsumerSettings))(actorSystem, kafkaClusterConfig, backupConfig)
                   }
                 }
             }

--- a/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/S3App.scala
+++ b/cli-backup/src/main/scala/io/aiven/guardian/kafka/backup/S3App.scala
@@ -1,11 +1,11 @@
 package io.aiven.guardian.kafka.backup
 
 import akka.stream.alpakka.s3.S3Settings
-import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.s3.BackupClient
 import io.aiven.guardian.kafka.s3.{Config => S3Config}
 
-trait S3App extends S3Config with BackupApp with App[KafkaClient] {
-  lazy val s3Settings: S3Settings                           = S3Settings()
-  implicit lazy val backupClient: BackupClient[KafkaClient] = new BackupClient[KafkaClient](Some(s3Settings))
+trait S3App extends S3Config with BackupApp with App[KafkaConsumer] {
+  lazy val s3Settings: S3Settings                             = S3Settings()
+  implicit lazy val backupClient: BackupClient[KafkaConsumer] = new BackupClient[KafkaConsumer](Some(s3Settings))
 }

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/BackupClientInterface.scala
@@ -29,7 +29,7 @@ import java.time.temporal._
   * @tparam T
   *   The underlying `kafkaClientInterface` type
   */
-trait BackupClientInterface[T <: KafkaClientInterface] extends LazyLogging {
+trait BackupClientInterface[T <: KafkaConsumerInterface] extends LazyLogging {
   implicit val kafkaClientInterface: T
   implicit val backupConfig: Backup
   implicit val system: ActorSystem

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaConsumer.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaConsumer.scala
@@ -40,7 +40,7 @@ import java.util.Base64
   * @param kafkaClusterConfig
   *   Additional cluster configuration that is needed
   */
-class KafkaClient(
+class KafkaConsumer(
     configureConsumer: Option[
       ConsumerSettings[Array[Byte], Array[Byte]] => ConsumerSettings[Array[Byte], Array[Byte]]
     ] = None,
@@ -48,14 +48,14 @@ class KafkaClient(
       CommitterSettings => CommitterSettings
     ] = None
 )(implicit system: ActorSystem, kafkaClusterConfig: KafkaCluster, backupConfig: Backup)
-    extends KafkaClientInterface
+    extends KafkaConsumerInterface
     with LazyLogging {
   override type CursorContext        = CommittableOffset
   override type Control              = Consumer.Control
   override type MatCombineResult     = Consumer.DrainingControl[Done]
   override type BatchedCursorContext = CommittableOffsetBatch
 
-  import KafkaClient._
+  import KafkaConsumer._
 
   if (kafkaClusterConfig.topics.isEmpty)
     logger.warn("Kafka Cluster configuration has no topics set")
@@ -120,7 +120,7 @@ class KafkaClient(
     CommittableOffsetBatch(cursors.toSeq)
 }
 
-object KafkaClient {
+object KafkaConsumer {
   def consumerRecordToReducedConsumerRecord(
       consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]]
   ): ReducedConsumerRecord =

--- a/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaConsumerInterface.scala
+++ b/core-backup/src/main/scala/io/aiven/guardian/kafka/backup/KafkaConsumerInterface.scala
@@ -8,7 +8,7 @@ import io.aiven.guardian.kafka.models.ReducedConsumerRecord
 import scala.collection.immutable
 import scala.concurrent.Future
 
-trait KafkaClientInterface {
+trait KafkaConsumerInterface {
 
   /** The type of the context to pass around. In context of a Kafka consumer, this typically holds offset data to be
     * automatically committed

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 /** A wrapper that is designed to make it easier to cleanly shutdown resources in tests
   */
-class BackupClientControlWrapper[T <: KafkaClient](backupClient: BackupClientInterface[T])(implicit
+class BackupClientControlWrapper[T <: KafkaConsumer](backupClient: BackupClientInterface[T])(implicit
     materializer: Materializer,
     ec: ExecutionContext
 ) {

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedBackupClientInterface.scala
@@ -38,13 +38,13 @@ import java.util.concurrent.ConcurrentLinkedQueue
   *   `ByteString`. Use `mergeBackedUpData` to process `backedUpData` into a more convenient data structure once you
   *   have finished writing to it
   */
-class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafkaClientInterface,
+class MockedBackupClientInterface(override val kafkaClientInterface: MockedKafkaConsumerInterface,
                                   timeConfiguration: TimeConfiguration,
                                   compression: Option[CompressionModel] = None,
                                   backedUpData: ConcurrentLinkedQueue[(String, ByteString)] =
                                     new ConcurrentLinkedQueue[(String, ByteString)]()
 )(implicit override val system: ActorSystem)
-    extends BackupClientInterface[MockedKafkaClientInterface] {
+    extends BackupClientInterface[MockedKafkaConsumerInterface] {
 
   import MockedBackupClientInterface._
 
@@ -187,7 +187,7 @@ class MockedBackupClientInterfaceWithMockedKafkaData(
     handleOffsets: Boolean = false
 )(implicit override val system: ActorSystem)
     extends MockedBackupClientInterface(
-      new MockedKafkaClientInterface(kafkaData, commitStorage, stopAfterDuration, handleOffsets),
+      new MockedKafkaConsumerInterface(kafkaData, commitStorage, stopAfterDuration, handleOffsets),
       timeConfiguration,
       compression,
       backedUpData

--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaConsumerInterface.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/MockedKafkaConsumerInterface.scala
@@ -29,11 +29,11 @@ import java.util.concurrent.atomic.AtomicReference
   *   will only add commits to the `commitStorage` if its later than any currently processed offsets. Furthermore it
   *   will not replay source data if it has already been committed.
   */
-class MockedKafkaClientInterface(kafkaData: Source[ReducedConsumerRecord, NotUsed],
-                                 commitStorage: ConcurrentLinkedDeque[Long] = new ConcurrentLinkedDeque[Long](),
-                                 stopAfterDuration: Option[FiniteDuration] = None,
-                                 handleOffsets: Boolean = false
-) extends KafkaClientInterface {
+class MockedKafkaConsumerInterface(kafkaData: Source[ReducedConsumerRecord, NotUsed],
+                                   commitStorage: ConcurrentLinkedDeque[Long] = new ConcurrentLinkedDeque[Long](),
+                                   stopAfterDuration: Option[FiniteDuration] = None,
+                                   handleOffsets: Boolean = false
+) extends KafkaConsumerInterface {
 
   /** The type of the context to pass around. In context of a Kafka consumer, this typically holds offset data to be
     * automatically committed

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
@@ -12,7 +12,7 @@ import com.softwaremill.diffx.scalatest.DiffMustMatcher._
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.KafkaClusterTest
 import io.aiven.guardian.kafka.backup.BackupClientControlWrapper
-import io.aiven.guardian.kafka.backup.KafkaClient
+import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.configs.Backup
 import io.aiven.guardian.kafka.backup.configs.Compression
 import io.aiven.guardian.kafka.backup.configs.PeriodFromFirst
@@ -89,7 +89,7 @@ trait RealS3RestoreClientTest
 
         val backupClientWrapped =
           new BackupClientControlWrapper(
-            new BackupClient(Some(s3Settings))(new KafkaClient(configureConsumer = baseKafkaConfig),
+            new BackupClient(Some(s3Settings))(new KafkaConsumer(configureConsumer = baseKafkaConfig),
                                                implicitly,
                                                implicitly,
                                                implicitly,
@@ -128,7 +128,7 @@ trait RealS3RestoreClientTest
           _              <- createTopics(renamedTopics)
           _              <- akka.pattern.after(5 seconds)(restoreClient.restore)
           receivedTopics <- akka.pattern.after(1 minute)(eventualRestoredTopics.drainAndShutdown())
-          asConsumerRecords = receivedTopics.map(KafkaClient.consumerRecordToReducedConsumerRecord)
+          asConsumerRecords = receivedTopics.map(KafkaConsumer.consumerRecordToReducedConsumerRecord)
         } yield asConsumerRecords.toList
 
         calculatedFuture.onComplete { _ =>


### PR DESCRIPTION
# About this change - What it does

Renames two classes to better appropriate naming

Resolves: https://github.com/aiven/guardian-for-apache-kafka/issues/93

# Why this way

See the linked issue. Its just a basic IDE refactor/rename
