### PR TITLE
Increase timeout due to tests failing

### DIFF
--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -50,7 +50,7 @@ trait S3Spec
       )
 
   implicit val ec: ExecutionContext            = system.dispatcher
-  implicit val defaultPatience: PatienceConfig = PatienceConfig(10 minutes, 100 millis)
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(20 minutes, 100 millis)
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1)
 


### PR DESCRIPTION
# About this change - What it does

Timeouts are being caused with Guardian in actively running tests

# Why this way

This should at least prevent the tests from timing out.
