### PR TITLE
Remove Scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val flagsFor13 = Seq(
 )
 
 val librarySettings = Seq(
-  crossScalaVersions := List("2.12.17", "2.13.8"),
+  crossScalaVersions := List("2.13.8"),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n == 13 =>


### PR DESCRIPTION
# About this change - What it does

Removes Scala 2.12 support from Guardian.
# Why this way

When Lightbend did the last release of the Alpakka modules before BSL license change they forgot to make a release for Scala 2.12 which is causing problems with the github dependency uploader (see https://github.com/aiven/guardian-for-apache-kafka/actions/runs/3232747596/jobs/5295086621).

Scala 2.12 can be re-introduced when Pekko comes along
