### PR TITLE
Update Scala to 2.13.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.10]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.10]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -118,12 +118,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.13.8)
+      - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-2.13.8-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.13.10-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.8)
+      - name: Inflate target directories (2.13.10)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import com.jsuereth.sbtpgp.PgpKeys.publishSigned
 import com.lightbend.paradox.apidoc.ApidocPlugin.autoImport.apidocRootPackage
 
-ThisBuild / scalaVersion         := "2.13.8"
+ThisBuild / scalaVersion         := "2.13.10"
 ThisBuild / organization         := "aiven.io"
 ThisBuild / organizationName     := "Aiven"
 ThisBuild / organizationHomepage := Some(url("https://aiven.io/"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.codecommit"                    % "sbt-github-actions"       % 
 addSbtPlugin("com.github.sbt"                    % "sbt-pgp"                  % "2.1.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-release"              % "1.1.0")
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"             % "0.10.2")
-addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.3")
+addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.5")
 addSbtPlugin("org.scoverage"                     % "sbt-coveralls"            % "1.3.2")
 addSbtPlugin("net.vonbuchholtz"                  % "sbt-dependency-check"     % "4.1.0")
 


### PR DESCRIPTION
Updates Scala version.

Note that `Build and Test (ubuntu-latest, 2.13.8, temurin@11)` CI check won't run because its not triggered (due to change of Scala version). One this PR is merged the github status checks need to be updated.