### PR TITLE
Add a diffx ShowConfig to reduce test failure output

### DIFF
--- a/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
+++ b/core-s3/src/test/scala/io/aiven/guardian/kafka/s3/S3Spec.scala
@@ -11,6 +11,7 @@ import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.testkit.TestKitBase
+import com.softwaremill.diffx.ShowConfig
 import com.typesafe.scalalogging.LazyLogging
 import io.aiven.guardian.akka.AkkaHttpTestKit
 import io.aiven.guardian.kafka.TestUtils
@@ -51,6 +52,7 @@ trait S3Spec
 
   implicit val ec: ExecutionContext            = system.dispatcher
   implicit val defaultPatience: PatienceConfig = PatienceConfig(20 minutes, 100 millis)
+  implicit val showConfig: ShowConfig          = ShowConfig.default.skipIdentical
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1)
 


### PR DESCRIPTION
# About this change - What it does

Adds a `ShowConfig` to reduce output of identical elements of collections in a diff

# Why this way

When one of the test fails specifically due to structures not being matched correctly, currently it will also output all of the identical elements in the diff. Due to the size of the data structures we are dealing with (i.e. many mags) this output tends to be massive.

Using this `ShowConfig` significantly reduces the output, see https://diffx-scala.readthedocs.io/en/latest/usage/output.html?highlight=ShowConfig#skipping-identical for more info.
