### PR TITLE
Fix flaky tests

### DIFF
--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
@@ -145,7 +145,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
           reducedConsumerRecord
         }
 
-        calculatedFuture.onComplete { _ =>
+        calculatedFuture.onCompleteLogError { () =>
           cleanTopics(topics)
           backupClientWrapped.shutdown()
         }
@@ -246,7 +246,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
           (first, second)
         }
 
-        calculatedFuture.onComplete { _ =>
+        calculatedFuture.onCompleteLogError { () =>
           cleanTopics(topics)
           backupClientWrapped.shutdown()
           secondBackupClientWrapped.shutdown()
@@ -357,7 +357,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
           reducedConsumerRecord
         }
 
-        calculatedFuture.onComplete { _ =>
+        calculatedFuture.onCompleteLogError { () =>
           cleanTopics(topics)
           backupClientWrapped.shutdown()
           secondBackupClientWrapped.shutdown()
@@ -441,7 +441,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
         reducedConsumerRecord
       }
 
-      calculatedFuture.onComplete { _ =>
+      calculatedFuture.onCompleteLogError { () =>
         cleanTopics(topics)
         backupClientWrapped.shutdown()
       }
@@ -556,7 +556,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
                    }
           )
 
-          calculatedFuture.onComplete { _ =>
+          calculatedFuture.onCompleteLogError { () =>
             cleanTopics(topics)
             backupClientOneWrapped.shutdown()
             backupClientTwoWrapped.shutdown()
@@ -697,7 +697,7 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
                    }
           )
 
-          calculatedFuture.onComplete { _ =>
+          calculatedFuture.onCompleteLogError { () =>
             cleanTopics(topics)
             backupClientOneWrapped.shutdown()
             backupClientTwoWrapped.shutdown()

--- a/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
+++ b/backup-s3/src/test/scala/io/aiven/guardian/kafka/backup/s3/RealS3BackupClientTest.scala
@@ -65,7 +65,9 @@ trait RealS3BackupClientTest extends AnyPropSpecLike with KafkaClusterTest with 
   def getKeysFromTwoDownloads(dataBucket: String): Future[(String, String)] = waitForS3Download(
     dataBucket,
     {
-      case Seq(first, second) => (first.key, second.key)
+      case s if s.size == 2 =>
+        val sorted = s.sortBy(contents => Utils.keyToOffsetDateTime(contents.key))
+        (sorted(0).key, sorted(1).key)
       case rest =>
         throw DownloadNotReady(rest)
     }

--- a/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
+++ b/restore-s3/src/test/scala/io/aiven/guardian/kafka/restore/s3/RealS3RestoreClientTest.scala
@@ -11,6 +11,7 @@ import akka.stream.scaladsl.Sink
 import com.softwaremill.diffx.scalatest.DiffMustMatcher._
 import io.aiven.guardian.kafka.Generators._
 import io.aiven.guardian.kafka.KafkaClusterTest
+import io.aiven.guardian.kafka.TestUtils._
 import io.aiven.guardian.kafka.backup.BackupClientControlWrapper
 import io.aiven.guardian.kafka.backup.KafkaConsumer
 import io.aiven.guardian.kafka.backup.configs.Backup
@@ -131,7 +132,7 @@ trait RealS3RestoreClientTest
           asConsumerRecords = receivedTopics.map(KafkaConsumer.consumerRecordToReducedConsumerRecord)
         } yield asConsumerRecords.toList
 
-        calculatedFuture.onComplete { _ =>
+        calculatedFuture.onCompleteLogError { () =>
           cleanTopics(kafkaDataInChunksWithTimePeriodRenamedTopics.topics)
           cleanTopics(renamedTopics)
           backupClientWrapped.shutdown()


### PR DESCRIPTION
# About this change - What it does

Resolves a problem related to flaky tests as well as improvements to when tests fail

# Why this way

The main cause of the recent flaky tests is that S3 is not deterministic in the result ordering when we get bucket result contents, this was causing problems in tests that was specifically needing two keys, i.e. `getKeysFromTwoDownloads` (this is resolved in the `Sort the keys before returning them in getKeysFromTwoDownloads` commit). The other commits should be self explanatory.