### PR TITLE
Improve github scalafmt-native-action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,10 +9,7 @@ on:
 jobs:
   build:
     name: Code is formatted
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
@@ -21,6 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v1
+        uses: jrouly/scalafmt-native-action@v2
         with:
           version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
# About this change - What it does

Updates scalafmt native to the latest version as well as only applying scalafmt to change files.

# Why this way

Version updates is self explanatory. The `--mode diff-ref=origin/main` argument means that scalafmt will only format files that have changed from origin main (aka git ratcheting), improving the speed of scalafmt. Note that the `--list` needs to be provided since we are overriding the `arguments` (i.e. if you don't supply `arguments` then it defaults to `--list`)