### PR TITLE
Use explicit timeout rather than overriding PatienceConfig

### DIFF
--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/CompressionSpec.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/CompressionSpec.scala
@@ -5,6 +5,7 @@ import akka.stream.scaladsl.Compression
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.SourceWithContext
 import akka.util.ByteString
+import io.aiven.guardian.akka.AkkaStreamTestKit
 import io.aiven.guardian.akka.AnyPropTestKit
 import io.aiven.guardian.kafka.backup.configs.{Compression => CompressionModel}
 import io.aiven.guardian.kafka.models.Gzip
@@ -20,12 +21,13 @@ class CompressionSpec
     extends AnyPropTestKit(ActorSystem("CompressionSpec"))
     with Matchers
     with ScalaFutures
-    with ScalaCheckPropertyChecks {
+    with ScalaCheckPropertyChecks
+    with AkkaStreamTestKit {
 
   implicit val ec: ExecutionContext = system.dispatcher
 
-  // Its possible to generate a string with really bad entropy that causes the
-  // compression/decompression to take an unusually long amount of time
+  // Due to akka-streams taking a while to initialize for the first time we need a longer
+  // increase in the timeout
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(10 seconds, 15 millis)
 
   property("GZip compression works with a SourceWithContext/FlowWithContext") {


### PR DESCRIPTION
# About this change - What it does

Uses `AkkaStreamInitializationConstant` instead of an overridden `PatienceConfig` to account for a test taking a long time. Also as a bonus extending `AkkaStreamTestKit` means that that `ActorSystem` is properly shut down after test completes.

# Why this way

The reason provided in the previous solution to the problem at https://github.com/aiven/guardian-for-apache-kafka/pull/352 was likely a red herring. The issue is much more likely to be that when akka-streams is used for the first time have an initialisation delay and we forget to account for it with `AkkaStreamInitializationConstant`.
