### PR TITLE
Remove scalacheck fork by implementing buildableOfCollCond

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val core = project
       "com.typesafe.akka"          %% "akka-stream"                    % akkaVersion                % Test,
       "org.scalatest"              %% "scalatest"                      % scalaTestVersion           % Test,
       "org.scalatestplus"          %% scalaTestScalaCheckArtifact      % scalaTestScalaCheckVersion % Test,
-      "org.mdedetrich"             %% "scalacheck"                     % scalaCheckVersion          % Test,
+      "org.scalacheck"             %% "scalacheck"                     % scalaCheckVersion          % Test,
       "com.rallyhealth"            %% "scalacheck-ops_1-16"            % scalaCheckOpsVersion       % Test,
       "com.softwaremill.diffx"     %% "diffx-scalatest-must"           % diffxVersion               % Test,
       "com.typesafe.akka"          %% "akka-stream-testkit"            % akkaVersion                % Test,


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Replaces fork of scalacheck with official upstream one and as a result implements `listOfFillCond` natively.

# Why this way

Initially a fork of scalacheck was made in order to implement the ability to create a continuously growing generator. The fork was done because at the time I thought it was not possible to implement this without modifying the core of scalacheck. It turns out that I was incorrect in this, scalacheck has a `Gen.infiniteLazyList` which can be used to implement this functionality (see https://github.com/typelevel/scalacheck/pull/849#issuecomment-1264599632)
