### PR TITLE
Only shutdown if control is defined

### DIFF
--- a/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
+++ b/core-backup/src/test/scala/io/aiven/guardian/kafka/backup/BackupClientControlWrapper.scala
@@ -19,5 +19,10 @@ class BackupClientControlWrapper[T <: KafkaConsumer](backupClient: BackupClientI
   def run(): Unit =
     control = backupClient.backup.run()
 
-  def shutdown(): Future[Done] = control.drainAndShutdown()
+  @SuppressWarnings(Array("DisableSyntax.null"))
+  def shutdown(): Future[Done] =
+    if (control != null)
+      control.drainAndShutdown()
+    else
+      Future.successful(Done)
 }


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Only do a `shutdown` if a control is defined

# Why this way

Solves the problem with the following stack trace

```
Error:  [01/12/2023 15:49:19.612] [RealS3BackupClientSpec-akka.actor.default-dispatcher-7] [akka.dispatch.Dispatcher] null
java.lang.NullPointerException
	at io.aiven.guardian.kafka.backup.BackupClientControlWrapper.shutdown(BackupClientControlWrapper.scala:22)
	at io.aiven.guardian.kafka.backup.s3.RealS3BackupClientTest.$anonfun$$init$$38(RealS3BackupClientTest.scala:251)
	at io.aiven.guardian.kafka.TestUtils$ScalaFutureExtensionMethods.$anonfun$onCompleteLogError$1(TestUtils.scala:44)
	at io.aiven.guardian.kafka.TestUtils$ScalaFutureExtensionMethods.$anonfun$onCompleteLogError$1$adapted(TestUtils.scala:39)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:484)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```
