### PR TITLE
Integrate sbt-license-report

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ lazy val guardian = project
     cliRestore
   )
   .settings(
+    name               := s"$baseName-root",
     publish / skip     := true,
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
   )
@@ -356,7 +357,14 @@ lazy val docs = project
       "github.base_url" -> s"https://github.com/aiven/guardian-for-apache-kafka/tree/${if (isSnapshot.value) "main"
         else "v" + version.value}",
       "scaladoc.io.aiven.guardian.base_url" -> s"/guardian-for-apache-kafka/${(Preprocess / siteSubdirName).value}/"
-    )
+    ),
+    Compile / paradoxMarkdownToHtml / sourceGenerators += Def.taskDyn {
+      val targetFile = (Compile / paradox / sourceManaged).value / "license-report.md"
+
+      (LocalRootProject / dumpLicenseReportAggregate).map { dir =>
+        IO.copy(List(dir / s"$baseName-root-licenses.md" -> targetFile)).toList
+      }
+    }.taskValue
   )
 
 ThisBuild / homepage := Some(url("https://github.com/aiven/guardian-for-apache-kafka"))

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -11,6 +11,7 @@ to ensure that the tool runs reliably and as desired with large datasets in diff
 
 * [overview](overview.md)
 * [security](security.md)
+* [license-report](license-report.md)
 * [ci](ci.md)
 * [doc-generation](doc-generation.md)
 * [general-architecture](general-architecture/index.md)

--- a/project/LicenseReport.scala
+++ b/project/LicenseReport.scala
@@ -1,0 +1,25 @@
+import sbt._
+import sbtlicensereport.SbtLicenseReport
+import sbtlicensereport.SbtLicenseReport.autoImportImpl._
+import sbtlicensereport.license.{DepModuleInfo, MarkDown}
+
+object LicenseReport extends AutoPlugin {
+
+  override lazy val projectSettings = Seq(
+    licenseReportTypes      := Seq(MarkDown),
+    licenseReportMakeHeader := (language => language.header1("License Report")),
+    licenseConfigurations   := Set("compile", "test", "provided"),
+    licenseDepExclusions := {
+      case dep: DepModuleInfo if dep.organization == "io.aiven" && dep.name.contains("guardian") =>
+        true // Inter guardian project dependencies are pointless
+      case DepModuleInfo(_, "scala-library", _) => true // Scala library is part of Scala language
+      case DepModuleInfo(_, "scala-reflect", _) => true // Scala reflect is part of Scala language
+    },
+    licenseReportColumns := Seq(Column.Category, Column.License, Column.Dependency, Column.Configuration)
+  )
+
+  override def requires = plugins.JvmPlugin && SbtLicenseReport
+
+  override def trigger = allRequirements
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,7 @@ addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"             % 
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.7")
 addSbtPlugin("org.scoverage"                     % "sbt-coveralls"            % "1.3.8")
 addSbtPlugin("net.vonbuchholtz"                  % "sbt-dependency-check"     % "5.1.0")
+addSbtPlugin("com.github.sbt"                    % "sbt-license-report"       % "1.5.0")
 
 // This is here to bump dependencies for sbt-paradox/sbt-site, see
 // https://github.com/sirthias/parboiled/issues/175, https://github.com/sirthias/parboiled/issues/128 and


### PR DESCRIPTION
# About this change - What it does

Integrates [sbt-license-report](https://github.com/sbt/sbt-license-report) into paradox which provides an transitive scan of all dependencies licenses directly into guardian documentation.

# Why this way

The approach used here is similar to what was done in Pekko https://github.com/apache/incubator-pekko/pull/319. The only major difference is that I opted to remove `Column.OriginatingArtifactName` from the columns because it caused the generated report to have way too much noise. `Column.OriginatingArtifactName` means that the report displays which dependencies are coming from which artifacts but since Guardian is meant to be used as an application its not that relevant (also as you can see from the generated report all of our dependencies are Apache/MIT/GPL etc etc so its not like there are some artifacts that have "problematic" licenses).

Generated report looks like this
![image](https://github.com/aiven/guardian-for-apache-kafka/assets/2337269/b2745db7-eb96-4685-85c5-c881b81d35e1)

