### PR TITLE
Change sbt-site to sbt-site-paradox

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.lightbend.paradox"             % "sbt-paradox-project-info" % 
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"               % "0.5.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-ghpages"              % "0.8.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"         % "3.0.2")
-addSbtPlugin("com.github.sbt"                    % "sbt-site"                 % "1.5.0")
+addSbtPlugin("com.github.sbt"                    % "sbt-site-paradox"         % "1.5.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-native-packager"      % "1.9.16")
 addSbtPlugin("com.codecommit"                    % "sbt-github-actions"       % "0.14.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-pgp"                  % "2.2.1")


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Current sbt build is broken with latest sbt-site updated.

# Why this way

sbt-site split out its paradox support into a separate plugin, see https://www.scala-sbt.org/sbt-site//migration-guide.html#migrating-from-version-1-4-x-to-1-5-x
