### PR TITLE
Pin Pekko snapshot dependencies for now

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,4 @@
 updatePullRequests = "always"
+
+# Remove when Pekko is released
+updates.pin = [{ groupId = "org.apache.pekko", version = "0.0." }]


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Pekko currently doesn't have a release and due to this we are using snapshots.

# Why this way

Due to the usage of snapshots and the fact that they update nightly, its best to pin pekko snapshot updates
