### PR TITLE
github: add scala steward action

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+name: Launch Scala Steward
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-22.04
+    name: Launch Scala Steward
+    steps:
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-app-id: ${{ secrets.APP_ID }}
+          github-app-installation-id: ${{ secrets.APP_INSTALLATION_ID }}
+          github-app-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# About this change - What it does
Run Scala Steward as a GitHub Action to allow better compatibility with other actions in this repository.

# Why this way
Some GitHub Actions fail when invoked due to a Pull Request from a fork. This means all external Scala Steward submitted PRs have failing CI runs and we don't know if a dependency update will cause issues. Using a GitHub App combined with the GitHub Action in the repository gets around this and CI should be able to run correctly.